### PR TITLE
PF-35 Some R wrapper updates

### DIFF
--- a/TimeSeries/PublicApis/R/Readme.md
+++ b/TimeSeries/PublicApis/R/Readme.md
@@ -2,7 +2,9 @@
 
 The R programming environment provides a rich ecosystem for numerical computing and graphic visualization.
 
-Requires: [an R runtime](https://cran.rstudio.com/) 3.3-or-greater, any supported platform
+Requires:
+- [an R runtime](https://cran.rstudio.com/) 3.3-or-greater, any supported platform
+- AQTS 2017.2 or later - To get time-aligned time-series data
 
 ### Recommended packages
 


### PR DESCRIPTION
@GordPollock-AI Can you have a look? This just adds a bit of version-checking to the R wrapper, to make the failure a bit more obvious if someone tries to run this against a pre-17.2 build of AQTS.

1) Added version checking for the server version

2) Fail if the server is not running AQTS 17.2 when asking for time-aligned data

3) Updated the readme to note the 17.2 requirement