### PR TITLE
AQ-22322 Add ExampleFieldDataPlugins

### DIFF
--- a/TimeSeries/PublicApis/FieldDataPlugins/ExampleFieldDataPlugins.sln
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ExampleFieldDataPlugins.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StageDischargePlugin", "StageDischargePlugin\StageDischargePlugin.csproj", "{BAA6EB6F-2010-4692-BA22-F4388D0C62E2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ManualGaugingPlugin", "ManualGaugingPlugin\ManualGaugingPlugin.csproj", "{3AB6F814-D489-4EFF-ACD0-B99C6A28D73C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BAA6EB6F-2010-4692-BA22-F4388D0C62E2}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{BAA6EB6F-2010-4692-BA22-F4388D0C62E2}.Debug|x64.ActiveCfg = Debug|x64
+		{BAA6EB6F-2010-4692-BA22-F4388D0C62E2}.Debug|x64.Build.0 = Debug|x64
+		{BAA6EB6F-2010-4692-BA22-F4388D0C62E2}.Release|Any CPU.ActiveCfg = Release|x64
+		{BAA6EB6F-2010-4692-BA22-F4388D0C62E2}.Release|x64.ActiveCfg = Release|x64
+		{BAA6EB6F-2010-4692-BA22-F4388D0C62E2}.Release|x64.Build.0 = Release|x64
+		{3AB6F814-D489-4EFF-ACD0-B99C6A28D73C}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{3AB6F814-D489-4EFF-ACD0-B99C6A28D73C}.Debug|x64.ActiveCfg = Debug|x64
+		{3AB6F814-D489-4EFF-ACD0-B99C6A28D73C}.Debug|x64.Build.0 = Debug|x64
+		{3AB6F814-D489-4EFF-ACD0-B99C6A28D73C}.Release|Any CPU.ActiveCfg = Release|x64
+		{3AB6F814-D489-4EFF-ACD0-B99C6A28D73C}.Release|x64.ActiveCfg = Release|x64
+		{3AB6F814-D489-4EFF-ACD0-B99C6A28D73C}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/CreatorBase.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/CreatorBase.cs
@@ -1,0 +1,20 @@
+﻿using ManualGaugingPlugin.FileData;
+using Server.BusinessInterfaces.FieldDataPluginCore;
+
+namespace ManualGaugingPlugin
+{
+    public abstract class CreatorBase<T>
+    {
+        protected readonly FieldVisitRecord FieldVisit;
+
+        protected readonly ILog Log;
+
+        protected CreatorBase(FieldVisitRecord record, ILog logger)
+        {
+            FieldVisit = record;
+            Log = logger;
+        }
+
+        public abstract T Create();
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/DischargeActivityCreator.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/DischargeActivityCreator.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using ManualGaugingPlugin.FileData;
+using Server.BusinessInterfaces.FieldDataPluginCore;
+using Server.BusinessInterfaces.FieldDataPluginCore.Context;
+using Server.BusinessInterfaces.FieldDataPluginCore.DataModel;
+using Server.BusinessInterfaces.FieldDataPluginCore.DataModel.ChannelMeasurements;
+using Server.BusinessInterfaces.FieldDataPluginCore.DataModel.DischargeActivities;
+using Measurement = Server.BusinessInterfaces.FieldDataPluginCore.DataModel.Measurement;
+
+namespace ManualGaugingPlugin
+{
+    public class DischargeActivityCreator : CreatorBase<DischargeActivity>
+    {
+        private readonly LocationInfo _location;
+
+        public DischargeActivityCreator(FieldVisitRecord record, LocationInfo location, ILog logger) : base(record, logger)
+        {
+            _location = location;
+        }
+
+        public override DischargeActivity Create()
+        {
+            //NOTE: Timestamps are specified as DateTimeOffset, which requires UTC-offset.
+            //If field data file timestamps do not include UTC-offset, plugin can create DateTimeOffset objects using location's UTC-offset.
+            var startTime = new DateTimeOffset(FieldVisit.StartDate, _location.UtcOffset);
+            var endTime = new DateTimeOffset(FieldVisit.EndDate, _location.UtcOffset);
+            var interval = new DateTimeInterval(startTime, endTime);
+
+            var dischargeSection = GetManualGaugingDischargeSection(interval);
+
+            var factory = new DischargeActivityFactory(FieldVisit.UnitSystem);
+            var dischargeActivity = factory.CreateDischargeActivity(interval, dischargeSection.Discharge.Value);
+            Log.Info(
+                $"Creating discharge activity from {interval.Start} to {interval.End} with discharge value = {dischargeSection.Discharge.Value}");
+
+            AddGageHeightMeasurements(interval, dischargeActivity);
+            dischargeActivity.ChannelMeasurements.Add(dischargeSection);
+
+            return dischargeActivity;
+        }
+
+        private void AddGageHeightMeasurements(DateTimeInterval measurementInterval, DischargeActivity dischargeActivity)
+        {
+            var startGageHeight = new Measurement(FieldVisit.DischargeActivity.StartGageHeight,
+                FieldVisit.UnitSystem.DistanceUnitId);
+            var endGageHeight = new Measurement(FieldVisit.DischargeActivity.EndGageHeight,
+                FieldVisit.UnitSystem.DistanceUnitId);
+
+            dischargeActivity.GageHeightMeasurements.Add(new GageHeightMeasurement(startGageHeight,
+                measurementInterval.Start));
+            dischargeActivity.GageHeightMeasurements.Add(new GageHeightMeasurement(endGageHeight,
+                measurementInterval.End));
+        }
+
+        private ManualGaugingDischargeSection GetManualGaugingDischargeSection(DateTimeInterval measurementPeriod)
+        {
+            var creator = new ManualGaugingCreator(FieldVisit, measurementPeriod, Log);
+            return creator.Create();
+        }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/DoubleHelper.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/DoubleHelper.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace ManualGaugingPlugin
+{
+    public static class DoubleHelper
+    {
+        private const int MaxUlps = 4;
+
+        // Adapted from https://msdn.microsoft.com/en-us/library/ya2zha7s(v=vs.110).aspx
+        public static bool HasMinimalDifference(double value1, double value2)
+        {
+            var lValue1 = BitConverter.DoubleToInt64Bits(value1);
+            var lValue2 = BitConverter.DoubleToInt64Bits(value2);
+
+            // If the signs are different, return false except for +0 and -0.
+            if ((lValue1 >> 63) != (lValue2 >> 63))
+            {
+                return value1 == value2;
+            }
+
+            var diff = Math.Abs(lValue1 - lValue2);
+            return diff <= MaxUlps;
+        }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/FieldDataResultsGenerator.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/FieldDataResultsGenerator.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using ManualGaugingPlugin.FileData;
+using Server.BusinessInterfaces.FieldDataPluginCore;
+using Server.BusinessInterfaces.FieldDataPluginCore.Context;
+using Server.BusinessInterfaces.FieldDataPluginCore.DataModel;
+using Server.BusinessInterfaces.FieldDataPluginCore.DataModel.DischargeActivities;
+using Server.BusinessInterfaces.FieldDataPluginCore.Results;
+
+namespace ManualGaugingPlugin
+{
+    public class FieldDataResultsGenerator
+    {
+        private readonly IFieldDataResultsAppender _resultsAppender;
+        private readonly LocationInfo _location;
+        private readonly ILog _log;
+
+        public FieldDataResultsGenerator(IFieldDataResultsAppender resultsAppender, LocationInfo location, ILog log)
+        {
+            _resultsAppender = resultsAppender;
+            _location = location;
+            _log = log;
+        }
+
+        public void GenerateFieldDataResults(FieldVisitRecord record)
+        {
+            var visitDetails = CreateFieldVisitDetails(record);
+            var fieldVisit = _resultsAppender.AddFieldVisit(_location, visitDetails);
+            _log.Info(
+                $"Creating field visit with start date {visitDetails.StartDate} and end date {visitDetails.EndDate} for location {_location.LocationIdentifier}");
+
+            var dischargeActivity = CreateDischargeActivity(record);
+            _resultsAppender.AddDischargeActivity(fieldVisit, dischargeActivity);
+        }
+
+        private FieldVisitDetails CreateFieldVisitDetails(FieldVisitRecord record)
+        {
+            //NOTE: Timestamps are specified as DateTimeOffset, which requires UTC-offset.
+            //If field data file timestamps do not include UTC-offset, plugin can create DateTimeOffset objects using location's UTC-offset.
+            var startTime = new DateTimeOffset(record.StartDate, _location.UtcOffset);
+            var endTime = new DateTimeOffset(record.EndDate, _location.UtcOffset);
+            var interval = new DateTimeInterval(startTime, endTime);
+
+            return new FieldVisitDetails(interval);
+        }
+
+        private DischargeActivity CreateDischargeActivity(FieldVisitRecord fieldVisit)
+        {
+            var creator = new DischargeActivityCreator(fieldVisit, _location, _log);
+            return creator.Create();
+        }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/FileData/DischargeActivityRecord.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/FileData/DischargeActivityRecord.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Server.BusinessInterfaces.FieldDataPluginCore.DataModel.Verticals;
+
+namespace ManualGaugingPlugin.FileData
+{
+    public class DischargeActivityRecord
+    {
+        public double StartGageHeight { get; set; }
+        public double EndGageHeight { get; set; }
+        public Meter Meter { get; set; }
+        public PointVelocityObservationType ObservationMethodType { get; set; }
+        public List<ManualGaugingRecord> ManualGaugings { get; set; }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/FileData/FieldVisitRecord.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/FileData/FieldVisitRecord.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Server.BusinessInterfaces.FieldDataPluginCore.Units;
+
+namespace ManualGaugingPlugin.FileData
+{
+    public class FieldVisitRecord
+    {
+        //It is best practice to use LocationUniqueId (can be discovered via Publish API or Springboard UI) because it is guaranteed to be unique string.
+        //It is also OK to use the LocationIdentifier but be aware that a user can change the LocationIdentifier using LocationManager or Provisioning API.
+        public string LocationIdentifier { get; private set; }
+
+        //Ideally, StartDate and EndDate are defined as DateTimeOffset, as timestamps in AQUARIUS are always specified with a UTC-offset.
+        //However, it is common that timestamps in files do not include an UTC-offset.
+        public DateTime StartDate { get; private set; }
+        public DateTime EndDate { get; private set; }
+
+        public DischargeActivityRecord DischargeActivity { get; set; }
+
+        public UnitSystem UnitSystem { get; private set; }
+
+        public FieldVisitRecord(UnitSystem unitSystem, string locationIdentifier, DateTime startDate, DateTime endDate)
+        {
+            UnitSystem = unitSystem;
+            LocationIdentifier = locationIdentifier;
+            StartDate = startDate;
+            EndDate = endDate;
+        }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/FileData/ManualGaugingRecord.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/FileData/ManualGaugingRecord.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace ManualGaugingPlugin.FileData
+{
+    public class ManualGaugingRecord
+    {
+        public double TaglinePosition { get; set; }
+        public double SoundedDepth { get; set; }
+        public List<VelocityObservation> Observations { get; set; }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/FileData/Meter.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/FileData/Meter.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace ManualGaugingPlugin.FileData
+{
+    public class Meter
+    {
+        public string Model { get; set; }
+        public string SerialNumber { get; set; }
+        public string Manufacturer { get; set; }
+        public List<MeterEquation> Equations { get; set; }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/FileData/MeterEquation.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/FileData/MeterEquation.cs
@@ -1,0 +1,18 @@
+﻿namespace ManualGaugingPlugin.FileData
+{
+    public class MeterEquation
+    {
+        public double StartRange { get; private set; }
+        public double EndRange { get; private set; }
+        public double Intercept { get; private set; }
+        public double Slope { get; private set; }
+
+        public MeterEquation(double startRange, double endRange, double slope, double intercept)
+        {
+            StartRange = startRange;
+            EndRange = endRange;
+            Intercept = intercept;
+            Slope = slope;
+        }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/FileData/VelocityObservation.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/FileData/VelocityObservation.cs
@@ -1,0 +1,9 @@
+﻿namespace ManualGaugingPlugin.FileData
+{
+    public class VelocityObservation
+    {
+        public double ObservationDepth { get; set; }
+        public int Revolutions { get; set; }
+        public int IntervalInSeconds { get; set; }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/FileReader.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/FileReader.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using ManualGaugingPlugin.FileData;
+
+namespace ManualGaugingPlugin
+{
+    public class FileReader
+    {
+        public FieldVisitRecord ReadFile(Stream fileStream)
+        {
+            using (var reader = CreateStreamReader(fileStream))
+            {
+                //TODO - Read field data from file.
+                const string locationIdentifierFromFile = "ExampleLocationIdentifier";
+                var startDateReadFromFile = new DateTime(2017, 09, 27, 0, 0, 0);
+                var endDateReadFromFile = new DateTime(2017, 09, 27, 23, 59, 59);
+                return new FieldVisitRecord(new MetricUnitSystem(), locationIdentifierFromFile, startDateReadFromFile,
+                    endDateReadFromFile);
+            }
+        }
+
+        private static StreamReader CreateStreamReader(Stream fileStream)
+        {
+            const int defaultByteBufferSize = 1024;
+
+            //NOTE: Make sure to set leaveOpen property on StreamReader so the Stream does not close when the StreamReader closes.
+            //Framework will take care of closing the Stream.
+            return new StreamReader(fileStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true,
+            bufferSize: defaultByteBufferSize, leaveOpen: true);
+        }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/ManualGaugingCreator.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/ManualGaugingCreator.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using ManualGaugingPlugin.FileData;
+using Server.BusinessInterfaces.FieldDataPluginCore;
+using Server.BusinessInterfaces.FieldDataPluginCore.DataModel;
+using Server.BusinessInterfaces.FieldDataPluginCore.DataModel.ChannelMeasurements;
+using Server.BusinessInterfaces.FieldDataPluginCore.DataModel.Verticals;
+
+namespace ManualGaugingPlugin
+{
+    public class ManualGaugingCreator : CreatorBase<ManualGaugingDischargeSection>
+    {
+        private readonly DateTimeInterval _measurementPeriod;
+
+        //NOTE: When an enum (e.g. PointVelocityObservationType, DeploymentType) includes both "Unknown" and "Unspecified" enumerations, use the
+        //"Unspecified" enumeration.
+        public ManualGaugingCreator(FieldVisitRecord record, DateTimeInterval measurementPeriod, ILog logger) : base(record, logger)
+        {
+            _measurementPeriod = measurementPeriod;
+        }
+
+        public override ManualGaugingDischargeSection Create()
+        {
+            var verticals = GetVerticals();
+            var results = new ManualGaugingResultSummary(verticals);
+
+            var factory = new ManualGaugingDischargeSectionFactory(FieldVisit.UnitSystem);
+            var manualGauging = factory.CreateManualGaugingDischargeSection(_measurementPeriod,
+                results.TotalDischarge);
+
+            manualGauging.DischargeMethod = DischargeMethodType.MeanSection;
+            manualGauging.VelocityObservationMethod = FieldVisit.DischargeActivity.ObservationMethodType;
+            manualGauging.StartPoint = StartPointType.LeftEdgeOfWater;
+            manualGauging.DeploymentMethod = DeploymentMethodType.Unspecified;
+
+            foreach (var vertical in verticals)
+            {
+                manualGauging.Verticals.Add(vertical);
+            }
+
+            manualGauging.WidthValue = results.TotalWidth;
+            manualGauging.AreaValue = results.TotalArea;
+            manualGauging.VelocityAverageValue = results.MeanVelocity;
+
+            Log.Info($"Creating ManualGaugingDischargeSection with {manualGauging.Verticals.Count} verticals");
+
+            return manualGauging;
+        }
+
+        private List<Vertical> GetVerticals()
+        {
+            var verticalsCreator = new VerticalsCreator(FieldVisit, _measurementPeriod, Log);
+            return verticalsCreator.Create();
+        }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/ManualGaugingPlugin.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/ManualGaugingPlugin.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.IO;
+using ManualGaugingPlugin.FileData;
+using Server.BusinessInterfaces.FieldDataPluginCore;
+using Server.BusinessInterfaces.FieldDataPluginCore.Context;
+using Server.BusinessInterfaces.FieldDataPluginCore.Results;
+
+namespace ManualGaugingPlugin
+{
+    public class ManualGaugingPlugin : IFieldDataPlugin
+    {
+        public ParseFileResult ParseFile(Stream fileStream, IFieldDataResultsAppender fieldDataResultsAppender, ILog logger)
+        {
+            var fieldVisit = ReadFile(fileStream);
+
+            try
+            {
+                var location = fieldDataResultsAppender.GetLocationByIdentifier(fieldVisit.LocationIdentifier);
+                logger.Info($"Parsing field data for location {location.LocationIdentifier}");
+
+                var resultsGenerator = new FieldDataResultsGenerator(fieldDataResultsAppender, location, logger);
+                return GetFieldDataResults(resultsGenerator, fieldVisit);
+            }
+            catch (Exception)
+            {
+                logger.Error($"Cannot parse file, location {fieldVisit.LocationIdentifier} not found");
+                return ParseFileResult.CannotParse();
+            }
+        }
+
+        public ParseFileResult ParseFile(Stream fileStream, LocationInfo targetLocation,
+            IFieldDataResultsAppender fieldDataResultsAppender, ILog logger)
+        {
+            var fieldVisit = ReadFile(fileStream);
+
+            //Only save data if it matches the targetLocation.
+            if (!targetLocation.LocationIdentifier.Equals(fieldVisit.LocationIdentifier))
+            {
+                return ParseFileResult.CannotParse();
+            }
+
+            var resultsGenerator = new FieldDataResultsGenerator(fieldDataResultsAppender, targetLocation, logger);
+            return GetFieldDataResults(resultsGenerator, fieldVisit);
+        }
+
+        private static FieldVisitRecord ReadFile(Stream fileStream)
+        {
+            var reader = new FileReader();
+            return reader.ReadFile(fileStream);
+        }
+
+        private static ParseFileResult GetFieldDataResults(FieldDataResultsGenerator resultsGenerator, FieldVisitRecord record)
+        {
+            try
+            {
+                resultsGenerator.GenerateFieldDataResults(record);
+                return ParseFileResult.SuccessfullyParsedAndDataValid();
+            }
+            catch (Exception ex)
+            {
+                return ParseFileResult.SuccessfullyParsedButDataInvalid(ex);
+            }
+        }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/ManualGaugingPlugin.csproj
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/ManualGaugingPlugin.csproj
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3AB6F814-D489-4EFF-ACD0-B99C6A28D73C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ManualGaugingPlugin</RootNamespace>
+    <AssemblyName>ManualGaugingPlugin</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Server.BusinessInterfaces.FieldDataPluginCore">
+      <HintPath>..\FieldDataPlugins\Library\Server.BusinessInterfaces.FieldDataPluginCore.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CreatorBase.cs" />
+    <Compile Include="DischargeActivityCreator.cs" />
+    <Compile Include="DoubleHelper.cs" />
+    <Compile Include="FieldDataResultsGenerator.cs" />
+    <Compile Include="FileData\DischargeActivityRecord.cs" />
+    <Compile Include="FileData\ManualGaugingRecord.cs" />
+    <Compile Include="FileData\FieldVisitRecord.cs" />
+    <Compile Include="FileData\MeterEquation.cs" />
+    <Compile Include="FileData\Meter.cs" />
+    <Compile Include="FileData\VelocityObservation.cs" />
+    <Compile Include="FileReader.cs" />
+    <Compile Include="ManualGaugingCreator.cs" />
+    <Compile Include="ManualGaugingPlugin.cs" />
+    <Compile Include="ManualGaugingResultSummary.cs" />
+    <Compile Include="MeterCalibrationCreator.cs" />
+    <Compile Include="MetricUnitSystem.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="VerticalsCreator.cs" />
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/ManualGaugingResultSummary.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/ManualGaugingResultSummary.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Server.BusinessInterfaces.FieldDataPluginCore.DataModel.Verticals;
+
+namespace ManualGaugingPlugin
+{
+    public class ManualGaugingResultSummary
+    {
+        public double TotalWidth { get; }
+        public double TotalArea { get; }
+        public double TotalDischarge { get; }
+        public double MeanVelocity { get; }
+
+        private readonly List<Vertical> _verticals;
+
+        public ManualGaugingResultSummary(List<Vertical> verticals)
+        {
+            _verticals = verticals;
+
+            TotalWidth = CalculateTotalWidth();
+            TotalArea = CalculateTotalArea();
+            TotalDischarge = CalculateTotalDischarge();
+            MeanVelocity = CalculateMeanVelocity();
+        }
+
+
+        private double CalculateTotalWidth()
+        {
+            return _verticals.Where(v => v.Segment != null).Sum(v => v.Segment.Width);
+        }
+
+        private double CalculateTotalArea()
+        {
+            return _verticals.Where(v => v.Segment != null).Sum(v => v.Segment.Area);
+        }
+
+        private double CalculateTotalDischarge()
+        {
+            return _verticals.Where(v => v.Segment != null).Sum(v => v.Segment.Discharge);
+        }
+
+        private double CalculateMeanVelocity()
+        {
+            return TotalDischarge / TotalArea;
+        }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/MeterCalibrationCreator.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/MeterCalibrationCreator.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using ManualGaugingPlugin.FileData;
+using Server.BusinessInterfaces.FieldDataPluginCore;
+using Server.BusinessInterfaces.FieldDataPluginCore.DataModel.Meters;
+
+namespace ManualGaugingPlugin
+{
+    public class MeterCalibrationCreator : CreatorBase<MeterCalibration>
+    {
+        public MeterCalibrationCreator(FieldVisitRecord record, ILog logger) : base(record, logger)
+        {
+        }
+
+        public override MeterCalibration Create()
+        {
+            var calibration = new MeterCalibration
+            {
+                Model = FieldVisit.DischargeActivity.Meter.Model,
+                Manufacturer = FieldVisit.DischargeActivity.Meter.Manufacturer,
+                SerialNumber = FieldVisit.DischargeActivity.Meter.SerialNumber,
+                MeterType = MeterType.Unspecified
+            };
+
+            foreach (var equation in GetMeterEquations())
+            {
+                calibration.Equations.Add(equation);
+            }
+
+            return calibration;
+        }
+
+        public List<MeterCalibrationEquation> GetMeterEquations()
+        {
+            return FieldVisit.DischargeActivity.Meter.Equations.Select(equation => new MeterCalibrationEquation
+            {
+                Intercept = equation.Intercept,
+                InterceptUnitId = FieldVisit.UnitSystem.DistanceUnitId,
+                RangeStart = equation.StartRange,
+                RangeEnd = equation.EndRange,
+                Slope = equation.Slope
+            }).ToList();
+        }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/MetricUnitSystem.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/MetricUnitSystem.cs
@@ -1,0 +1,18 @@
+﻿using Server.BusinessInterfaces.FieldDataPluginCore.Units;
+
+namespace ManualGaugingPlugin
+{
+    public class MetricUnitSystem : UnitSystem
+    {
+        public MetricUnitSystem()
+        {
+            //UnitIds are found by calling 
+            // - GetUnits in Provisioning API and using the "UnitIdentifier" property
+            // - GetUnits in Publish API and using the "Identifier" property
+            DistanceUnitId = "m";
+            AreaUnitId = "m^2";
+            VelocityUnitId = "m/s";
+            DischargeUnitId = "m^3/s";
+        }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/Properties/AssemblyInfo.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ManualGaugingPlugin")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Hewlett-Packard Company")]
+[assembly: AssemblyProduct("ManualGaugingPlugin")]
+[assembly: AssemblyCopyright("Copyright © Hewlett-Packard Company 2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("3ab6f814-d489-4eff-acd0-b99c6a28d73c")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/Properties/AssemblyInfo.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/Properties/AssemblyInfo.cs
@@ -1,26 +1,8 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("ManualGaugingPlugin")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Hewlett-Packard Company")]
-[assembly: AssemblyProduct("ManualGaugingPlugin")]
-[assembly: AssemblyCopyright("Copyright © Hewlett-Packard Company 2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("3ab6f814-d489-4eff-acd0-b99c6a28d73c")]
 
 // Version information for an assembly consists of the following four values:
 //

--- a/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/VerticalsCreator.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/ManualGaugingPlugin/VerticalsCreator.cs
@@ -1,0 +1,234 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ManualGaugingPlugin.FileData;
+using Server.BusinessInterfaces.FieldDataPluginCore;
+using Server.BusinessInterfaces.FieldDataPluginCore.DataModel;
+using Server.BusinessInterfaces.FieldDataPluginCore.DataModel.ChannelMeasurements;
+using Server.BusinessInterfaces.FieldDataPluginCore.DataModel.Meters;
+using Server.BusinessInterfaces.FieldDataPluginCore.DataModel.Verticals;
+using VelocityObservation = Server.BusinessInterfaces.FieldDataPluginCore.DataModel.Verticals.VelocityObservation;
+
+namespace ManualGaugingPlugin
+{
+    public class VerticalsCreator : CreatorBase<List<Vertical>>
+    {
+        private readonly DateTimeInterval _measurementPeriod;
+
+        private readonly int _startEdgeSequenceNumber;
+        private readonly int _endEdgeSequenceNumber;
+
+        public VerticalsCreator(FieldVisitRecord record, DateTimeInterval measurementPeriod, ILog logger)
+            : base(record, logger)
+        {
+            _measurementPeriod = measurementPeriod;
+
+            _startEdgeSequenceNumber = 1;
+            _endEdgeSequenceNumber = record.DischargeActivity.ManualGaugings.Count;
+        }
+
+        public override List<Vertical> Create()
+        {
+            var verticals = new List<Vertical>();
+            Vertical precedingVertical = null;
+            for (var i = 0; i < FieldVisit.DischargeActivity.ManualGaugings.Count; i++)
+            {
+                var gauging = FieldVisit.DischargeActivity.ManualGaugings[i];
+                var sequenceNumber = i + 1;
+                var vertical = sequenceNumber == _startEdgeSequenceNumber
+                    ? GetStartEdgeVertical(gauging)
+                    : GetVertical(gauging, precedingVertical, sequenceNumber);
+
+                verticals.Add(vertical);
+                precedingVertical = vertical;
+            }
+
+            SetTotalDischargePortionForEachVertical(verticals);
+            return verticals;
+        }
+
+        private Vertical GetStartEdgeVertical(ManualGaugingRecord gauging)
+        {
+            return GetVertical(gauging, _startEdgeSequenceNumber, VerticalType.StartEdgeNoWaterBefore);
+        }
+
+        private Vertical GetVertical(ManualGaugingRecord gauging, Vertical precedingVertical, int sequenceNumber)
+        {
+            var verticalType = sequenceNumber == _endEdgeSequenceNumber
+                ? VerticalType.EndEdgeNoWaterAfter
+                : VerticalType.MidRiver;
+
+            var vertical = GetVertical(gauging, sequenceNumber, verticalType);
+
+            var segment = GetSegment(gauging, vertical.VelocityObservation, precedingVertical);
+            vertical.Segment = segment;
+
+            return vertical;
+        }
+
+        private Vertical GetVertical(ManualGaugingRecord gauging, int sequenceNumber, VerticalType verticalType)
+        {
+            var measurementTime = CalculateMeasurementTime();
+            var velocityObservation = GetVelocityObservation(gauging);
+
+            Log.Info($"Vertical: {sequenceNumber}");
+
+            return new Vertical
+            {
+                SequenceNumber = sequenceNumber,
+                FlowDirection = FlowDirectionType.Normal,
+                IsSoundedDepthEstimated = false,
+                MeasurementTime = measurementTime,
+                SoundedDepth = gauging.SoundedDepth,
+                TaglinePosition = gauging.TaglinePosition,
+                EffectiveDepth = gauging.SoundedDepth,
+                VerticalType = verticalType,
+                MeasurementConditionData = new OpenWaterData(),
+                VelocityObservation = velocityObservation
+            };
+        }
+
+        private DateTimeOffset CalculateMeasurementTime()
+        {
+            var ticks = _measurementPeriod.End.Subtract(_measurementPeriod.Start).Ticks / 2;
+            return _measurementPeriod.Start.AddTicks(ticks);
+        }
+
+        private VelocityObservation GetVelocityObservation(ManualGaugingRecord gauging)
+        {
+            var meterCalibration = GetMeterCalibration();
+            var depthObservations = GetVelocityDepthObservations(gauging, meterCalibration);
+            var meanVelocity = CalculateMeanVelocity(depthObservations);
+            var observationMethod = FieldVisit.DischargeActivity.ObservationMethodType;
+
+            var velocityObservation = new VelocityObservation
+            {
+                MeanVelocity = meanVelocity,
+                VelocityObservationMethod = observationMethod,
+                MeterCalibration = meterCalibration,
+                DeploymentMethod = DeploymentMethodType.Unspecified
+            };
+
+            foreach (var observation in depthObservations)
+            {
+                velocityObservation.Observations.Add(observation);
+            }
+
+            Log.Info($"VelocityObservation: VMV={meanVelocity}, observationMethod={observationMethod}");
+
+            return velocityObservation;
+        }
+
+        private MeterCalibration GetMeterCalibration()
+        {
+            var meterCreator = new MeterCalibrationCreator(FieldVisit, Log);
+            return meterCreator.Create();
+        }
+
+        private List<VelocityDepthObservation> GetVelocityDepthObservations(ManualGaugingRecord gauging,
+            MeterCalibration meterCalibration)
+        {
+            return gauging.Observations.Select(observation =>
+            {
+                var revolutionCount = observation.Revolutions;
+                var observationInterval = observation.IntervalInSeconds;
+                if (observation.Revolutions == 0 || observation.IntervalInSeconds == 0)
+                {
+                    revolutionCount = 0;
+                    observationInterval = 0;
+                }
+
+                var velocity = CalculateDepthObservationVelocity(revolutionCount, observationInterval, meterCalibration);
+
+                return new VelocityDepthObservation
+                {
+                    Depth = observation.ObservationDepth,
+                    IsVelocityEstimated = false,
+                    RevolutionCount = revolutionCount,
+                    Velocity = velocity,
+                    ObservationInterval = observationInterval
+                };
+            }).ToList();
+        }
+
+        private double CalculateDepthObservationVelocity(int revolutionCount, int observationInterval,
+            MeterCalibration meterCalibration)
+        {
+            var velocity = 0.0;
+
+            var frequency = (float) revolutionCount/observationInterval;
+            foreach (var equation in meterCalibration.Equations)
+            {
+                var rangeStart = equation.RangeStart.GetValueOrDefault();
+                var rangeEnd = equation.RangeEnd.GetValueOrDefault();
+
+                if (frequency > rangeStart &&
+                    (frequency < rangeEnd || DoubleHelper.HasMinimalDifference(frequency, rangeEnd)))
+                {
+                    velocity = frequency*equation.Slope + equation.Intercept;
+                    break;
+                }
+            }
+
+            Log.Info(
+                $"VelocityDepthObservation: Revolutions={revolutionCount}, Interval={observationInterval}, Frequency={frequency} m/s, Velocity={velocity} m/s");
+
+            return velocity;
+        }
+
+        private static double CalculateMeanVelocity(IReadOnlyCollection<VelocityDepthObservation> observations)
+        {
+            return !observations.Any() ? 0.0d : observations.Average(s => s.Velocity);
+        }
+
+        private Segment GetSegment(ManualGaugingRecord gauging, VelocityObservation velocityObservation, Vertical precedingVertical)
+        {
+            var segmentVelocity = CalculateSegmentVelocity(velocityObservation, precedingVertical);
+            var segmentWidth = CalculateSegmentWidth(gauging, precedingVertical);
+            var segmentDepth = CalculateSegmentDepth(gauging, precedingVertical);
+            var segmentArea = segmentDepth * segmentWidth;
+            var segmentDischarge = segmentVelocity * segmentArea;
+
+            Log.Info(
+                $"Segment: Velocity={segmentVelocity} m/s, Depth={segmentDepth} m, Width={segmentWidth} m, Area={segmentArea} m^2, Discharge={segmentDischarge} m^3/s");
+
+            return new Segment
+            {
+                Area = segmentArea,
+                Discharge = segmentDischarge,
+                IsDischargeEstimated = false,
+                Velocity = segmentVelocity,
+                Width = segmentWidth
+            };
+        }
+
+        private static double CalculateSegmentVelocity(VelocityObservation velocityObservation,
+            Vertical precedingVertical)
+        {
+            return (precedingVertical.VelocityObservation.MeanVelocity + velocityObservation.MeanVelocity) / 2;
+        }
+
+        private static double CalculateSegmentWidth(ManualGaugingRecord gauging, Vertical precedingVertical)
+        {
+            return gauging.TaglinePosition - precedingVertical.TaglinePosition;
+        }
+
+        private static double CalculateSegmentDepth(ManualGaugingRecord gauging, Vertical precedingVertical)
+        {
+            return (gauging.SoundedDepth + precedingVertical.SoundedDepth) / 2;
+        }
+
+        private static void SetTotalDischargePortionForEachVertical(List<Vertical> verticals)
+        {
+            var totalDischarge = verticals.Where(v => v.Segment != null).Sum(v => v.Segment.Discharge);
+
+            foreach (var v in verticals)
+            {
+                if (v.Segment != null)
+                {
+                    v.Segment.TotalDischargePortion = v.Segment.Discharge / totalDischarge * 100;
+                }
+            }
+        }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/Readme.md
+++ b/TimeSeries/PublicApis/FieldDataPlugins/Readme.md
@@ -1,0 +1,51 @@
+## ExampleFieldDataPlugins.sln
+
+[**Download** this project folder](https://minhaskamal.github.io/DownGit/#/home?url=https:%2F%2Fgithub.com%2FAquaticInformatics%2FExamples%2Ftree%2Fmaster%2FTimeSeries%2FPublicApis%2FFieldDataPlugins)
+
+Requires: Visual Studio 2015+ (Community Edition is fine)
+
+The ExampleFieldDataPlugins solution includes some example plugins for the AQ-TS field data plugin framework.  The SDK is installed with your AQ-TS server, located at
+%Program Files%\AquaticInformatics\AQUARIUS Server\FieldDataPlugins\Library
+
+All plugins implement the interface Server.BusinessInterfaces.FieldDataPluginCore.IFieldDataPlugin
+
+### Examples
+
+The `StageDischargePlugin` example plugin demonstrates how to write a plugin to import simple stage-discharge pairs;
+
+The `ManualGaugingPlugin` example plugin demonstrates how to write a plugin to import point velocities;
+
+The example plugins do not provide an implementation of how to read and parse a field data file.  The functionality is stubbed out in FileReader.cs.  It is up to you to define the structure and format of the field data file.  Example file formats are CSV, JSON, XML, TXT.  Please note that the input to a plugin is a single file; if you need to provide multiple files as input to your plugin, consider using ZIP as your field data file format.
+
+### Logging
+
+Every method signature in the IFieldDataPlugin interface includes a reference to a Server.BusinessInterfaces.FieldDataPluginCore.ILog object.
+
+Log messages are written to the `FieldDataPluginFramework.log`, which can be found on the server at %Program Data%\Aquatic Informatics\AQUARIUS\Logs.
+
+### Best Practices
+
+Please consider the following best practices when writing your plugin:
+- Plugins run in a sandbox environment - the framework runs plugins locally, so plugins should not access the network;
+- Plugins must be thread safe;
+- Plugins should only contain managed code - AI will not provide developer support for plugins containing unmanaged code;
+- Plugins should be able to process a field data file in less than one second.
+
+### Installing a plugin
+
+Plugins are installed on every AQTS server in the folder %ProgramFiles%\AquaticInformatics\AQUARIUS Server\FieldDataPlugins.
+
+Each plugin and its dependencies are contained in its own sub-folder in the FieldDataPlugins folder.  For example, your plugin, YourPlugin.dll, and its dependencies will be installed on the server in the folder %ProgramFiles%\AquaticInformatics\AQUARIUS Server\FieldDataPlugins\YourPlugin.
+
+However, the field data plugin framework will not run a plugin until it is registered.
+
+### Registering a plugin
+
+Use `GET /Provisioning/v1/fielddataplugins` to get a list of registered plugins.
+
+Use `POST /Provisioning/v1/fielddataplugins` to register a field data plugin
+- `PluginFolderName` is the name of the sub-folder in the %ProgramFiles%\AquaticInformatics\AQUARIUS Server\FieldDataPlugins\ folder that contains your plugin and its dependencies;
+- `AssemblyQualifiedTypeName` is described [here by MSDN](https://docs.microsoft.com/en-us/dotnet/framework/reflection-and-codedom/specifying-fully-qualified-type-names).  An example of an assembly qualified name is, YourPlugin, CustomerProjectNamespace.YourPlugin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null.
+
+Use `DELETE /Provisioning/v1/fielddataplugins/{UniqueId}` to unregister a field data plugin
+- The `UniqueId` is a unique string value identifying your field data plugin.  Each plugin is assigned a UniqueId when it is registered.  Use `GET /Provisioning/v1/fielddataplugins` to look-up the UniqueId of any plugin.

--- a/TimeSeries/PublicApis/FieldDataPlugins/Readme.md
+++ b/TimeSeries/PublicApis/FieldDataPlugins/Readme.md
@@ -21,7 +21,7 @@ The example plugins do not provide an implementation of how to read and parse a 
 
 Every method signature in the IFieldDataPlugin interface includes a reference to a Server.BusinessInterfaces.FieldDataPluginCore.ILog object.
 
-Log messages are written to the `FieldDataPluginFramework.log`, which can be found on the server at %Program Data%\Aquatic Informatics\AQUARIUS\Logs.
+Log messages are written to the `FieldDataPluginFramework.log`, which can be found on the server at `%Program Data%\Aquatic Informatics\AQUARIUS\Logs`.
 
 ### Best Practices
 

--- a/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/DischargeActivityCreator.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/DischargeActivityCreator.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Server.BusinessInterfaces.FieldDataPluginCore;
+using Server.BusinessInterfaces.FieldDataPluginCore.Context;
+using Server.BusinessInterfaces.FieldDataPluginCore.DataModel;
+using Server.BusinessInterfaces.FieldDataPluginCore.DataModel.DischargeActivities;
+using StageDischargePlugin.FileData;
+using Measurement = Server.BusinessInterfaces.FieldDataPluginCore.DataModel.Measurement;
+
+namespace StageDischargePlugin
+{
+    public class DischargeActivityCreator
+    {
+        private readonly LocationInfo _location;
+        private readonly FieldVisitRecord _fieldVisit;
+        private readonly ILog _log;
+
+        public DischargeActivityCreator(FieldVisitRecord record, LocationInfo location, ILog logger)
+        {
+            _fieldVisit = record;
+            _location = location;
+            _log = logger;
+        }
+
+        public DischargeActivity Create()
+        {
+            //NOTE: Timestamps are specified as DateTimeOffset, which requires UTC-offset.
+            //If field data file timestamps do not include UTC-offset, plugin can create DateTimeOffset objects using location's UTC-offset.
+            var startTime = new DateTimeOffset(_fieldVisit.StartDate, _location.UtcOffset);
+            var endTime = new DateTimeOffset(_fieldVisit.EndDate, _location.UtcOffset);
+            var interval = new DateTimeInterval(startTime, endTime);
+
+            var factory = new DischargeActivityFactory(_fieldVisit.UnitSystem);
+            var dischargeActivity = factory.CreateDischargeActivity(interval, _fieldVisit.DischargeActivity.Discharge);
+            _log.Info(
+                $"Creating discharge activity from {interval.Start} to {interval.End} with discharge value = {_fieldVisit.DischargeActivity.Discharge}");
+
+            AddGageHeightMeasurements(interval, dischargeActivity);
+            dischargeActivity.Comments = _fieldVisit.DischargeActivity.Comments;
+            dischargeActivity.Party = _fieldVisit.DischargeActivity.Party;
+            dischargeActivity.MeasurementId = _fieldVisit.DischargeActivity.MeasurementId;
+
+            return dischargeActivity;
+        }
+
+        private void AddGageHeightMeasurements(DateTimeInterval measurementInterval, DischargeActivity dischargeActivity)
+        {
+            var startGageHeight = new Measurement(_fieldVisit.DischargeActivity.StartGageHeight,
+                _fieldVisit.UnitSystem.DistanceUnitId);
+            var endGageHeight = new Measurement(_fieldVisit.DischargeActivity.EndGageHeight,
+                _fieldVisit.UnitSystem.DistanceUnitId);
+
+            dischargeActivity.GageHeightMeasurements.Add(new GageHeightMeasurement(startGageHeight,
+                measurementInterval.Start));
+            dischargeActivity.GageHeightMeasurements.Add(new GageHeightMeasurement(endGageHeight,
+                measurementInterval.End));
+        }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/FieldDataResultsGenerator.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/FieldDataResultsGenerator.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Server.BusinessInterfaces.FieldDataPluginCore;
+using Server.BusinessInterfaces.FieldDataPluginCore.Context;
+using Server.BusinessInterfaces.FieldDataPluginCore.DataModel;
+using Server.BusinessInterfaces.FieldDataPluginCore.DataModel.DischargeActivities;
+using Server.BusinessInterfaces.FieldDataPluginCore.Results;
+using StageDischargePlugin.FileData;
+
+namespace StageDischargePlugin
+{
+    public class FieldDataResultsGenerator
+    {
+        private readonly IFieldDataResultsAppender _resultsAppender;
+        private readonly LocationInfo _location;
+        private readonly ILog _log;
+
+        public FieldDataResultsGenerator(IFieldDataResultsAppender resultsAppender, LocationInfo location, ILog log)
+        {
+            _resultsAppender = resultsAppender;
+            _location = location;
+            _log = log;
+        }
+
+        public void GenerateFieldDataResults(FieldVisitRecord record)
+        {
+            var visitDetails = CreateFieldVisitDetails(record);
+            var fieldVisit = _resultsAppender.AddFieldVisit(_location, visitDetails);
+            _log.Info(
+                $"Creating field visit with start date {visitDetails.StartDate} and end date {visitDetails.EndDate} for location {_location.LocationIdentifier}");
+
+            var dischargeActivity = CreateDischargeActivity(record);
+            _resultsAppender.AddDischargeActivity(fieldVisit, dischargeActivity);
+        }
+
+        private FieldVisitDetails CreateFieldVisitDetails(FieldVisitRecord record)
+        {
+            //NOTE: Timestamps are specified as DateTimeOffset, which requires UTC-offset.
+            //If field data file timestamps do not include UTC-offset, plugin can create DateTimeOffset objects using location's UTC-offset.
+            var startTime = new DateTimeOffset(record.StartDate, _location.UtcOffset);
+            var endTime = new DateTimeOffset(record.EndDate, _location.UtcOffset);
+            var interval = new DateTimeInterval(startTime, endTime);
+
+            return new FieldVisitDetails(interval);
+        }
+
+        private DischargeActivity CreateDischargeActivity(FieldVisitRecord record)
+        {
+            var creator = new DischargeActivityCreator(record, _location, _log);
+            return creator.Create();
+        }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/FileData/DischargeActivityRecord.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/FileData/DischargeActivityRecord.cs
@@ -1,0 +1,12 @@
+﻿namespace StageDischargePlugin.FileData
+{
+    public class DischargeActivityRecord
+    {
+        public string MeasurementId { get; set; }
+        public double StartGageHeight { get; set; }
+        public double EndGageHeight { get; set; }
+        public double Discharge { get; set; }
+        public string Party { get; set; }
+        public string Comments { get; set; }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/FileData/FieldVisitRecord.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/FileData/FieldVisitRecord.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Server.BusinessInterfaces.FieldDataPluginCore.Units;
+
+namespace StageDischargePlugin.FileData
+{
+    public class FieldVisitRecord
+    {
+        //It is best practice to use LocationUniqueId (can be discovered via Publish API or Springboard UI) because it is guaranteed to be unique string.
+        //It is also OK to use the LocationIdentifier but be aware that a user can change the LocationIdentifier using LocationManager or Provisioning API.
+        public string LocationIdentifier { get; set; }
+
+        //Ideally, StartDate and EndDate are defined as DateTimeOffset, as timestamps in AQUARIUS are always specified with a UTC-offset.
+        //However, it is common that timestamps in files do not include an UTC-offset.
+        public DateTime StartDate { get; set; }
+        public DateTime EndDate { get; set; }
+
+        public DischargeActivityRecord DischargeActivity { get; set; }
+
+        public UnitSystem UnitSystem { get; private set; }
+
+        public FieldVisitRecord(UnitSystem unitSystem, string locationIdentifier, DateTime startDate, DateTime endDate)
+        {
+            UnitSystem = unitSystem;
+            LocationIdentifier = locationIdentifier;
+            StartDate = startDate;
+            EndDate = endDate;
+        }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/FileReader.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/FileReader.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using StageDischargePlugin.FileData;
+
+namespace StageDischargePlugin
+{
+    public class FileReader
+    {
+        public FieldVisitRecord ReadFile(Stream fileStream)
+        {
+            using (var reader = CreateStreamReader(fileStream))
+            {
+                //TODO - Read field data from file.
+                const string locationIdentifierFromFile = "ExampleLocationIdentifier";
+                var startDateReadFromFile = new DateTime(2017, 09, 27, 0, 0, 0);
+                var endDateReadFromFile = new DateTime(2017, 09, 27, 23, 59, 59);
+                return new FieldVisitRecord(new MetricUnitSystem(), locationIdentifierFromFile, startDateReadFromFile,
+                    endDateReadFromFile);
+            }
+        }
+
+        private static StreamReader CreateStreamReader(Stream fileStream)
+        {
+            const int defaultByteBufferSize = 1024;
+
+            //NOTE: Make sure to set leaveOpen property on StreamReader so the Stream does not close when the StreamReader closes.
+            //Framework will take care of closing the Stream.
+            return new StreamReader(fileStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true,
+            bufferSize: defaultByteBufferSize, leaveOpen: true);
+        }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/MetricUnitSystem.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/MetricUnitSystem.cs
@@ -9,6 +9,7 @@ namespace StageDischargePlugin
             //UnitIds are found by calling 
             // - GetUnits in Provisioning API and using the "UnitIdentifier" property
             // - GetUnits in Publish API and using the "Identifier" property
+            //The "UnitIdentifier" property are system ids and cannot be modified.  So, it is safe to hardcode these values into your plugin.
             DistanceUnitId = "m";
             AreaUnitId = "m^2";
             VelocityUnitId = "m/s";

--- a/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/MetricUnitSystem.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/MetricUnitSystem.cs
@@ -1,0 +1,18 @@
+﻿using Server.BusinessInterfaces.FieldDataPluginCore.Units;
+
+namespace StageDischargePlugin
+{
+    public class MetricUnitSystem : UnitSystem
+    {
+        public MetricUnitSystem()
+        {
+            //UnitIds are found by calling 
+            // - GetUnits in Provisioning API and using the "UnitIdentifier" property
+            // - GetUnits in Publish API and using the "Identifier" property
+            DistanceUnitId = "m";
+            AreaUnitId = "m^2";
+            VelocityUnitId = "m/s";
+            DischargeUnitId = "m^3/s";
+        }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/Properties/AssemblyInfo.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/Properties/AssemblyInfo.cs
@@ -1,26 +1,11 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("ExampleFieldDataPlugins")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Hewlett-Packard Company")]
-[assembly: AssemblyProduct("ExampleFieldDataPlugins")]
-[assembly: AssemblyCopyright("Copyright © Hewlett-Packard Company 2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("baa6eb6f-2010-4692-ba22-f4388d0c62e2")]
 
 // Version information for an assembly consists of the following four values:
 //

--- a/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/Properties/AssemblyInfo.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ExampleFieldDataPlugins")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Hewlett-Packard Company")]
+[assembly: AssemblyProduct("ExampleFieldDataPlugins")]
+[assembly: AssemblyCopyright("Copyright © Hewlett-Packard Company 2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("baa6eb6f-2010-4692-ba22-f4388d0c62e2")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/StageDischargePlugin.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/StageDischargePlugin.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.IO;
+using Server.BusinessInterfaces.FieldDataPluginCore;
+using Server.BusinessInterfaces.FieldDataPluginCore.Context;
+using Server.BusinessInterfaces.FieldDataPluginCore.Results;
+using StageDischargePlugin.FileData;
+
+namespace StageDischargePlugin
+{
+    public class StageDischargePlugin : IFieldDataPlugin
+    {
+        public ParseFileResult ParseFile(Stream fileStream, IFieldDataResultsAppender fieldDataResultsAppender, ILog logger)
+        {
+            var fieldVisit = ReadFile(fileStream);
+
+            try
+            {
+                var location = fieldDataResultsAppender.GetLocationByIdentifier(fieldVisit.LocationIdentifier);
+                logger.Info($"Parsing field data for location {location.LocationIdentifier}");
+
+                var resultsGenerator = new FieldDataResultsGenerator(fieldDataResultsAppender, location, logger);
+                return GetFieldDataResults(resultsGenerator, fieldVisit);
+            }
+            catch (Exception)
+            {
+                logger.Error($"Cannot parse file, location {fieldVisit.LocationIdentifier} not found");
+                return ParseFileResult.CannotParse();
+            }
+        }
+
+        public ParseFileResult ParseFile(Stream fileStream, LocationInfo targetLocation,
+            IFieldDataResultsAppender fieldDataResultsAppender, ILog logger)
+        {
+            var fieldVisit = ReadFile(fileStream);
+
+            //Only save data if it matches the targetLocation.
+            if (!targetLocation.LocationIdentifier.Equals(fieldVisit.LocationIdentifier))
+            {
+                return ParseFileResult.CannotParse();
+            }
+
+            var resultsGenerator = new FieldDataResultsGenerator(fieldDataResultsAppender, targetLocation, logger);
+            return GetFieldDataResults(resultsGenerator, fieldVisit);
+        }
+
+        private static FieldVisitRecord ReadFile(Stream fileStream)
+        {
+            var reader = new FileReader();
+            return reader.ReadFile(fileStream);
+        }
+
+        private static ParseFileResult GetFieldDataResults(FieldDataResultsGenerator resultsGenerator, FieldVisitRecord record)
+        {
+            try
+            {
+                resultsGenerator.GenerateFieldDataResults(record);
+                return ParseFileResult.SuccessfullyParsedAndDataValid();
+            }
+            catch (Exception ex)
+            {
+                return ParseFileResult.SuccessfullyParsedButDataInvalid(ex);
+            }
+        }
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/StageDischargePlugin.csproj
+++ b/TimeSeries/PublicApis/FieldDataPlugins/StageDischargePlugin/StageDischargePlugin.csproj
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{BAA6EB6F-2010-4692-BA22-F4388D0C62E2}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>StageDischargePlugin</RootNamespace>
+    <AssemblyName>StageDischargePlugin</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Server.BusinessInterfaces.FieldDataPluginCore">
+      <HintPath>..\FieldDataPlugins\Library\Server.BusinessInterfaces.FieldDataPluginCore.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DischargeActivityCreator.cs" />
+    <Compile Include="FieldDataResultsGenerator.cs" />
+    <Compile Include="FileData\DischargeActivityRecord.cs" />
+    <Compile Include="FileData\FieldVisitRecord.cs" />
+    <Compile Include="FileReader.cs" />
+    <Compile Include="MetricUnitSystem.cs" />
+    <Compile Include="StageDischargePlugin.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
Created a solution containing two example field data plugins to demonstrate how to write a plugin for the field data plugin framework.  The plugins compile, but they do not import data because it is missing functionality to read and parse a field data file.  This functionality is stubbed out in FileReader.cs.