### PR TITLE
PF-64 Store the plugin and framework assembly qualified name in the JSON result

### DIFF
--- a/TimeSeries/PublicApis/FieldDataPlugins/PluginTester/AppendedResults.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/PluginTester/AppendedResults.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using Server.BusinessInterfaces.FieldDataPluginCore.Context;
+
+namespace PluginTester
+{
+    public class AppendedResults
+    {
+        public string FrameworkAssemblyQualifiedName { get; set; }
+        public string PluginAssemblyQualifiedTypeName { get; set; }
+        public List<FieldVisitInfo> AppendedVisits { get; set; } = new List<FieldVisitInfo>();
+    }
+}

--- a/TimeSeries/PublicApis/FieldDataPlugins/PluginTester/FieldDataResultsAppender.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/PluginTester/FieldDataResultsAppender.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Server.BusinessInterfaces.FieldDataPluginCore;
 using Server.BusinessInterfaces.FieldDataPluginCore.Context;
 using Server.BusinessInterfaces.FieldDataPluginCore.DataModel;
 using Server.BusinessInterfaces.FieldDataPluginCore.DataModel.CrossSection;
@@ -26,7 +27,11 @@ namespace PluginTester
         }
 
         public LocationInfo LocationInfo { get; set; }
-        public List<FieldVisitInfo> AppendedVisits { get; } = new List<FieldVisitInfo>();
+
+        public AppendedResults AppendedResults { get; } = new AppendedResults
+        {
+            FrameworkAssemblyQualifiedName = typeof(IFieldDataPlugin).AssemblyQualifiedName
+        };
 
         public LocationInfo GetLocationByIdentifier(string locationIdentifier)
         {
@@ -54,7 +59,7 @@ namespace PluginTester
         {
             var fieldVisitInfo = InternalConstructor<FieldVisitInfo>.Invoke(location, fieldVisitDetails);
 
-            AppendedVisits.Add(fieldVisitInfo);
+            AppendedResults.AppendedVisits.Add(fieldVisitInfo);
 
             return fieldVisitInfo;
         }

--- a/TimeSeries/PublicApis/FieldDataPlugins/PluginTester/PluginTester.csproj
+++ b/TimeSeries/PublicApis/FieldDataPlugins/PluginTester/PluginTester.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AppendedResults.cs" />
     <Compile Include="ExpectedException.cs" />
     <Compile Include="FieldDataResultsAppender.cs" />
     <Compile Include="InternalConstructor.cs" />

--- a/TimeSeries/PublicApis/FieldDataPlugins/PluginTester/Program.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/PluginTester/Program.cs
@@ -140,13 +140,16 @@ namespace PluginTester
 
                 try
                 {
+                    appender.AppendedResults.PluginAssemblyQualifiedTypeName = plugin.GetType().AssemblyQualifiedName;
+
                     var result = string.IsNullOrEmpty(LocationIdentifier)
                         ? plugin.ParseFile(stream, appender, logger)
                         : plugin.ParseFile(stream, locationInfo, appender, logger);
 
-                    SaveAppendedData(appender);
 
-                    SummarizeResults(result, appender);
+                    SaveAppendedResults(appender.AppendedResults);
+
+                    SummarizeResults(result, appender.AppendedResults);
                 }
                 catch (Exception exception)
                 {
@@ -157,17 +160,17 @@ namespace PluginTester
             }
         }
 
-        private void SaveAppendedData(FieldDataResultsAppender appender)
+        private void SaveAppendedResults(AppendedResults appendedResults)
         {
             if (string.IsNullOrEmpty(JsonPath))
                 return;
 
-            Log.Info($"Saving {appender.AppendedVisits.Count} visits data to '{JsonPath}'");
+            Log.Info($"Saving {appendedResults.AppendedVisits.Count} visits data to '{JsonPath}'");
 
-            File.WriteAllText(JsonPath, appender.AppendedVisits.ToJson().IndentJson());
+            File.WriteAllText(JsonPath, appendedResults.ToJson().IndentJson());
         }
 
-        private void SummarizeResults(ParseFileResult result, FieldDataResultsAppender appender)
+        private void SummarizeResults(ParseFileResult result, AppendedResults appendedResults)
         {
             if (!result.Parsed)
             {
@@ -189,13 +192,13 @@ namespace PluginTester
             }
             else
             {
-                if (!appender.AppendedVisits.Any())
+                if (!appendedResults.AppendedVisits.Any())
                 {
                     Log.Warn("File was parsed but no visits were appended.");
                 }
                 else
                 {
-                    Log.Info($"Successfully parsed {appender.AppendedVisits.Count} visits.");
+                    Log.Info($"Successfully parsed {appendedResults.AppendedVisits.Count} visits.");
                 }
             }
         }


### PR DESCRIPTION
This will help us know which versions were used to generate the JSON.