### PR TITLE
PF-70 The plugin tester now uses an in-memory stream

### DIFF
--- a/TimeSeries/PublicApis/FieldDataPlugins/PluginTester/PluginTester.csproj
+++ b/TimeSeries/PublicApis/FieldDataPlugins/PluginTester/PluginTester.csproj
@@ -42,6 +42,7 @@
     </Reference>
     <Reference Include="ServiceStack.Text, Version=4.5.14.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\ServiceStack.Text.4.5.14\lib\net45\ServiceStack.Text.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/TimeSeries/PublicApis/FieldDataPlugins/PluginTester/Program.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/PluginTester/Program.cs
@@ -210,7 +210,7 @@ namespace PluginTester
 
             Log.Info($"Loading data file '{DataPath}'");
 
-            return new FileStream(DataPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            return new MemoryStream(File.ReadAllBytes(DataPath));
         }
 
         private IFieldDataPlugin LoadPlugin()
@@ -220,6 +220,7 @@ namespace PluginTester
             if (!File.Exists(pluginPath))
                 throw new ExpectedException($"Plugin file '{pluginPath}' does not exist.");
 
+            // ReSharper disable once PossibleNullReferenceException
             var assembliesInPluginFolder = new FileInfo(pluginPath).Directory.GetFiles("*.dll");
 
             AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>


### PR DESCRIPTION
This will prevent a plugin developer from successfully casting the Stream parameter to a FileStream subclass when trying to get the uploaded filename.

This change fixes a bug where a plugin would work within the test hardness but fail at runtime.