### PR TITLE
PF-70 The field data plugin test now uses a MemoryStream instead of a FileStream

### DIFF
--- a/TimeSeries/PublicApis/FieldDataPlugins/PluginTester/Program.cs
+++ b/TimeSeries/PublicApis/FieldDataPlugins/PluginTester/Program.cs
@@ -210,7 +210,11 @@ namespace PluginTester
 
             Log.Info($"Loading data file '{DataPath}'");
 
-            return new MemoryStream(File.ReadAllBytes(DataPath));
+            using (var stream = new FileStream(DataPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using(var reader = new BinaryReader(stream))
+            {
+                return new MemoryStream(reader.ReadBytes((int)stream.Length));
+            }
         }
 
         private IFieldDataPlugin LoadPlugin()


### PR DESCRIPTION
This more closely simulates the environment of the real plugin framework.