### PR TITLE
Issue-48 Minor TimeSeriesChangeMonitor improvements

### DIFF
--- a/TimeSeries/PublicApis/SdkExamples/SdkExamples.sln
+++ b/TimeSeries/PublicApis/SdkExamples/SdkExamples.sln
@@ -9,6 +9,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExternalProcessor", "Extern
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9A4C7B5E-822F-4468-8BE4-0AC4654FC2C9}"
 	ProjectSection(SolutionItems) = preProject
+		..\..\..\appveyor.yml = ..\..\..\appveyor.yml
 		Readme.md = Readme.md
 	EndProjectSection
 EndProject

--- a/TimeSeries/PublicApis/SdkExamples/TimeSeriesChangeMonitor/Context.cs
+++ b/TimeSeries/PublicApis/SdkExamples/TimeSeriesChangeMonitor/Context.cs
@@ -19,7 +19,8 @@ namespace TimeSeriesChangeMonitor
         public List<ExtendedAttributeFilter> ExtendedFilters { get; set; } = new List<ExtendedAttributeFilter>();
         public List<string> TimeSeries { get; set; } = new List<string>();
         public Instant ChangesSinceTime { get; set; } = Instant.FromDateTimeUtc(DateTime.UtcNow);
-        public Duration PollInterval { get; set; } = Duration.FromSeconds(10);
+        public Duration PollInterval { get; set; } = Duration.FromMinutes(5);
         public int MaximumChangeCount { get; set; }
+        public bool AllowQuickPolling { get; set; }
     }
 }

--- a/TimeSeries/PublicApis/SdkExamples/TimeSeriesChangeMonitor/Readme.md
+++ b/TimeSeries/PublicApis/SdkExamples/TimeSeriesChangeMonitor/Readme.md
@@ -4,11 +4,13 @@ Download the latest release [from the releases page](../../../../../../releases/
 
 The `TimeSeriesChangeMonitor.exe` console utility allows you easily monitor how quickly changes in your AQTS time-series become available for external consumption via Publish API.
 
-- It is a single .EXE, so nothing to install.
+- It is a single .EXE, so no installer is needed. Just download it and run it.
 - Requires the .NET 4.7 runtime installed (true for most up-to-date Windows systems)
 - Allows you fine tune all the `/GetTimeSeriesDescriptionList` request parameters, to precisely focus on only the changes you care about.
+- Works from `cmd.exe`, bash, or PowerShell.
 - Can run forever (until you type Ctrl-C), or can exit after a certain number of changes are detected.
 - Displays polling response summary statistics on exit, to help diagnose overall system performance.
+- All the output is also logged to `TimeSeriesChangeMonitor.log` in the same folder as the EXE.
 
 ## General help screen
 
@@ -32,9 +34,24 @@ Supported -option=value settings (/option=value works too):
   -ComputationPeriodIdentifier Optional computation period filter.
   -ExtendedFilters             Optional extended attribute filter in Name=Value format. Can be set multiple times.
   -TimeSeries                  Optional time-series to monitor. Can be set multiple times.
-  -ChangesSinceTime            The starting changes-since time. Defaults to 'right now'
-  -PollInterval                The polling interval [default: 0:00:00:10]
+  -ChangesSinceTime            The starting changes-since time in ISO 8601 format. Defaults to 'right now'
+  -PollInterval                The polling interval in ISO 8601 Duration format. [default: PT5M]
   -MaximumChangeCount          When greater than 0, exit after detecting this many changed time-series. [default: 0]
+  -AllowQuickPolling           Allows very quick polling. Good for testing, bad for production. [default: False]
+
+ISO 8601 timestamps use a yyyy'-'mm'-'dd'T'HH':'mm':'ss'.'fffffffzzz format.
+
+  The 7 fractional seconds digits are optional.
+  The zzz timezone can be 'Z' for UTC, or +HH:MM, or -HH:MM
+
+  Eg: 2017-04-01T00:00:00Z represents April 1st, 2017 in UTC.
+
+ISO 8601 durations use a 'PT'[nnH][nnM][nnS] format.
+
+  Only the required components are needed.
+
+  Eg: PT5M represents 5 minutes.
+      PT90S represents 90 seconds (1.5 minutes)
 
 Use the @optionsFile syntax to read more options from a file.
 
@@ -43,3 +60,33 @@ Use the @optionsFile syntax to read more options from a file.
   Comment lines begin with a # or // marker.
 ```
 
+## All the `/GetTimeSeriesDescriptionList` request filters are supported
+
+All of the request filters of the `GET /Publish/v2/GetTimeSeriesDescriptionList` request can be configured.
+
+- When no request filters are set, the command will monitor all the time-series in your AQTS system.
+- If you set multiple `/TimeSeries=` options, the tool will try to use the `LocationIdentifier`, `Parameter`, and/or `Publish` filters if all the monitored time-series have these values in common. This optimization will give optimum polling response times. 
+
+## Polling for changes quickly
+
+A large production system should not need to be polled for changes more frequently than about once every 5 minutes, and this utility enforces that limit by default.
+
+Polling more frequently is not super harmful, but putting too much pressure on the database is never a great idea.
+
+```sh
+$ ./TimeSeriesChangeMonitor.exe -server=doug-vm2012r2 -pollinterval=pt1s
+00:08:30.509 INFO  - Connecting TimeSeriesChangeMonitor v1.0.0.0 to doug-vm2012r2 ...
+00:08:31.109 INFO  - Connected to doug-vm2012r2 (2018.1.98.0)
+00:08:31.192 ERROR - Polling more quickly than every 5 minutes is not enabled.
+```
+
+But on test systems, or if you are simply impatient, you can set the `/AllowQuickPolling=True` option and poll more frequently. A `WARN` message will be logged to remind you that frequent polling on production systems is not recommended.
+
+```sh
+$ ./TimeSeriesChangeMonitor.exe -server=doug-vm2012r2 -pollinterval=pt1s -allowquickpolling=true
+00:09:18.957 INFO  - Connecting TimeSeriesChangeMonitor v1.0.0.0 to doug-vm2012r2 ...
+00:09:19.580 INFO  - Connected to doug-vm2012r2 (2018.1.98.0)
+00:09:19.634 WARN  - Polling more quickly than every 5 minutes is not recommended for production systems.
+00:09:19.643 INFO  - Monitoring all locations for changes in any time-series every 1 second
+00:09:19.643 INFO  - Press Ctrl+C or Ctrl+Break to exit.
+```


### PR DESCRIPTION
- Improved the Readme
- Added `AllowQuickPolling` and enforce the 5-minute minimum polling interval by default
- Set the `Parameter` and `Publish` filters when all monitored time-series share the same values