### PR TITLE
Issue-68 Some useful PointZilla improvements

### DIFF
--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/Context.cs
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/Context.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Aquarius.TimeSeries.Client.Helpers;
 using Aquarius.TimeSeries.Client.ServiceModels.Acquisition;
 using NodaTime;
 
@@ -20,6 +21,10 @@ namespace PointZilla
         public int? GradeCode { get; set; }
         public List<string> Qualifiers { get; set; } = new List<string>();
 
+        public CreateMode CreateMode { get; set; } = CreateMode.Never;
+        public Duration GapTolerance { get; set; } = DurationExtensions.MaxGapDuration;
+        public Offset? UtcOffset { get; set; }
+
         public TimeSeriesIdentifier SourceTimeSeries { get; set; }
         public Instant? SourceQueryFrom { get; set; }
         public Instant? SourceQueryTo { get; set; }
@@ -38,15 +43,14 @@ namespace PointZilla
 
         public List<string> CsvFiles { get; set; } = new List<string>();
 
-        // Use defaults which match AQTS Export-from-Springboard CSV format
-        public int CsvTimeField { get; set; } = 1;
-        public int CsvValueField { get; set; } = 3;
-        public int CsvGradeField { get; set; } = 5;
-        public int CsvQualifiersField { get; set; } = 6;
-        public string CsvComment { get; set; } = "#";
+        public int CsvTimeField { get; set; }
+        public int CsvValueField { get; set; }
+        public int CsvGradeField { get; set; }
+        public int CsvQualifiersField { get; set; }
+        public string CsvComment { get; set; }
         public int CsvSkipRows { get; set; }
         public string CsvTimeFormat { get; set; }
-        public bool CsvIgnoreInvalidRows { get; set; } = true;
+        public bool CsvIgnoreInvalidRows { get; set; }
         public bool CsvRealign { get; set; }
     }
 }

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/CreateMode.cs
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/CreateMode.cs
@@ -1,0 +1,9 @@
+﻿namespace PointZilla
+{
+    public enum CreateMode
+    {
+        Never,
+        Basic,
+        Reflected,
+    }
+}

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/Option.cs
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/Option.cs
@@ -11,12 +11,20 @@ namespace PointZilla
 
         public string UsageText()
         {
-            var defaultValue = Getter();
+            if (string.IsNullOrEmpty(Key) && string.IsNullOrEmpty(Description))
+                return string.Empty; // Omits a blank line
+
+            var key = string.IsNullOrEmpty(Key) ? SeparatorLine : "-" + Key.PadRight(KeyWidth);
+
+            var defaultValue = Getter != null ? Getter() : string.Empty;
 
             if (!string.IsNullOrEmpty(defaultValue))
                 defaultValue = $" [default: {defaultValue}]";
 
-            return $"{Key,-22} {Description}{defaultValue}";
+            return $"{key} {Description}{defaultValue}";
         }
+
+        private const int KeyWidth = 22;
+        private static readonly string SeparatorLine = string.Empty.PadRight(KeyWidth + 1, '=');
     }
 }

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/PointZilla.csproj
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/PointZilla.csproj
@@ -83,9 +83,11 @@
     <Compile Include="AquariusClientExtensions.cs" />
     <Compile Include="CommandType.cs" />
     <Compile Include="Context.cs" />
+    <Compile Include="CreateMode.cs" />
     <Compile Include="CsvReader.cs" />
     <Compile Include="ExpectedException.cs" />
     <Compile Include="ExternalPointsReader.cs" />
+    <Compile Include="TimeSeriesCreator.cs" />
     <Compile Include="WaveformGenerator.cs" />
     <Compile Include="WaveformType.cs" />
     <Compile Include="Option.cs" />

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/PointsAppender.cs
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/PointsAppender.cs
@@ -30,9 +30,20 @@ namespace PointZilla
                 .OrderBy(p => p.Time)
                 .ToList();
 
+            Log.Info($"Connecting to {Context.Server} ...");
+
             using (var client = AquariusClient.CreateConnectedClient(Context.Server, Context.Username, Context.Password))
             {
                 Log.Info($"Connected to {Context.Server} ({client.ServerVersion})");
+
+                if (Context.CreateMode != CreateMode.Never)
+                {
+                    new TimeSeriesCreator
+                    {
+                        Context = Context,
+                        Client = client
+                    }.CreateMissingTimeSeries(Context.TimeSeries);
+                }
 
                 var timeSeries = client.GetTimeSeriesInfo(Context.TimeSeries);
 

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/Program.cs
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/Program.cs
@@ -83,6 +83,8 @@ namespace PointZilla
         {
             var context = new Context();
 
+            SetNgCsvFormat(context);
+
             var resolvedArgs = args
                 .SelectMany(ResolveOptionsFromFile)
                 .ToArray();
@@ -96,26 +98,33 @@ namespace PointZilla
                 new Option {Key = nameof(context.Wait), Setter = value => context.Wait = bool.Parse(value), Getter = () => context.Wait.ToString(), Description = "Wait for the append request to complete"},
                 new Option {Key = nameof(context.AppendTimeout), Setter = value => context.AppendTimeout = TimeSpan.Parse(value), Getter = () => context.AppendTimeout.ToString(), Description = "Timeout period for append completion, in .NET TimeSpan format."},
 
+                new Option(), new Option {Description = "Time-series options:"},
                 new Option {Key = nameof(context.TimeSeries), Setter = value => context.TimeSeries = value, Getter = () => context.TimeSeries, Description = "Target time-series identifier or unique ID"},
                 new Option {Key = nameof(context.TimeRange), Setter = value => context.TimeRange = ParseInterval(value), Getter = () => context.TimeRange?.ToString(), Description = "Time-range for overwrite in ISO8061/ISO8601 (defaults to start/end points)"},
-                new Option {Key = nameof(context.Command), Setter = value => context.Command = (CommandType)Enum.Parse(typeof(CommandType), value, true), Getter = () => context.Command.ToString(), Description = $"Append operation to perform. One of {string.Join(", ", Enum.GetNames(typeof(CommandType)))}"},
+                new Option {Key = nameof(context.Command), Setter = value => context.Command = ParseEnum<CommandType>(value), Getter = () => context.Command.ToString(), Description = $"Append operation to perform.  {EnumOptions<CommandType>()}"},
                 new Option {Key = nameof(context.GradeCode), Setter = value => context.GradeCode = int.Parse(value), Getter = () => context.GradeCode.ToString(), Description = "Optional grade code for all appended points"},
                 new Option {Key = nameof(context.Qualifiers), Setter = value => context.Qualifiers = QualifiersParser.Parse(value), Getter = () => string.Join(",", context.Qualifiers), Description = "Optional qualifier list for all appended points"},
+                new Option {Key = nameof(context.CreateMode), Setter = value => context.CreateMode = ParseEnum<CreateMode>(value), Getter = () => context.CreateMode.ToString(), Description = $"Mode for creating missing time-series.  {EnumOptions<CreateMode>()}"},
+                new Option {Key = nameof(context.GapTolerance), Setter = value => context.GapTolerance = value.FromJson<Duration>(), Getter = () => context.GapTolerance.ToJson(), Description = "Set the gap tolerance for newly-created time-series."},
+                new Option {Key = nameof(context.UtcOffset), Setter = value => context.UtcOffset = value.FromJson<Offset>(), Getter = () => string.Empty, Description = "Set the UTC offset for any created location. [default: Use system timezone]"},
 
+                new Option(), new Option {Description = "Copy points from another time-series:"},
                 new Option {Key = nameof(context.SourceTimeSeries), Setter = value => {if (TimeSeriesIdentifier.TryParse(value, out var tsi)) context.SourceTimeSeries = tsi; }, Getter = () => context.SourceTimeSeries?.ToString(), Description = "Source time-series to copy. Prefix with [server2] or [server2:username2:password2] to copy from another server"},
                 new Option {Key = nameof(context.SourceQueryFrom), Setter = value => context.SourceQueryFrom = value.FromJson<Instant>(), Getter = () => context.SourceQueryFrom?.ToJson(), Description = "Start time of extracted points in ISO8601 format."},
                 new Option {Key = nameof(context.SourceQueryTo), Setter = value => context.SourceQueryTo = value.FromJson<Instant>(), Getter = () => context.SourceQueryTo?.ToJson(), Description = "End time of extracted points"},
 
+                new Option(), new Option {Description = "Point-generator options:"},
                 new Option {Key = nameof(context.StartTime), Setter = value => context.StartTime = value.FromJson<Instant>(), Getter = () => string.Empty, Description = "Start time of generated points, in ISO8601 format. [default: the current time]"},
                 new Option {Key = nameof(context.PointInterval), Setter = value => context.PointInterval = TimeSpan.Parse(value), Getter = () => context.PointInterval.ToString(), Description = "Interval between generated points, in .NET TimeSpan format."},
                 new Option {Key = nameof(context.NumberOfPoints), Setter = value => context.NumberOfPoints = int.Parse(value), Getter = () => context.NumberOfPoints.ToString(), Description = $"Number of points to generate. If 0, use {nameof(context.NumberOfPeriods)}"},
                 new Option {Key = nameof(context.NumberOfPeriods), Setter = value => context.NumberOfPeriods = double.Parse(value), Getter = () => context.NumberOfPeriods.ToString(CultureInfo.InvariantCulture), Description = "Number of waveform periods to generate."},
-                new Option {Key = nameof(context.WaveformType), Setter = value => context.WaveformType = (WaveformType)Enum.Parse(typeof(WaveformType), value, true), Getter = () => context.WaveformType.ToString(), Description = $"Waveform to generate. One of {string.Join(", ", Enum.GetNames(typeof(WaveformType)))}"},
+                new Option {Key = nameof(context.WaveformType), Setter = value => context.WaveformType = ParseEnum<WaveformType>(value), Getter = () => context.WaveformType.ToString(), Description = $"Waveform to generate. {EnumOptions<WaveformType>()}"},
                 new Option {Key = nameof(context.WaveformOffset), Setter = value => context.WaveformOffset = double.Parse(value), Getter = () => context.WaveformOffset.ToString(CultureInfo.InvariantCulture), Description = "Offset the generated waveform by this constant."},
                 new Option {Key = nameof(context.WaveformPhase), Setter = value => context.WaveformPhase = double.Parse(value), Getter = () => context.WaveformPhase.ToString(CultureInfo.InvariantCulture), Description = "Phase within one waveform period"},
                 new Option {Key = nameof(context.WaveformScalar), Setter = value => context.WaveformScalar = double.Parse(value), Getter = () => context.WaveformScalar.ToString(CultureInfo.InvariantCulture), Description = "Scale the waveform by this amount"},
                 new Option {Key = nameof(context.WaveformPeriod), Setter = value => context.WaveformPeriod = double.Parse(value), Getter = () => context.WaveformPeriod.ToString(CultureInfo.InvariantCulture), Description = "Waveform period before repeating"},
 
+                new Option(), new Option {Description = "CSV parsing options:"},
                 new Option {Key = "CSV", Setter = value => context.CsvFiles.Add(value), Getter = () => string.Join(", ", context.CsvFiles), Description = "Parse the CSV file"},
                 new Option {Key = nameof(context.CsvTimeField), Setter = value => context.CsvTimeField = int.Parse(value), Getter = () => context.CsvTimeField.ToString(), Description = "CSV column index for timestamps"},
                 new Option {Key = nameof(context.CsvValueField), Setter = value => context.CsvValueField = int.Parse(value), Getter = () => context.CsvValueField.ToString(), Description = "CSV column index for values"},
@@ -126,6 +135,22 @@ namespace PointZilla
                 new Option {Key = nameof(context.CsvSkipRows), Setter = value => context.CsvSkipRows = int.Parse(value), Getter = () => context.CsvSkipRows.ToString(), Description = "Number of CSV rows to skip before parsing"},
                 new Option {Key = nameof(context.CsvIgnoreInvalidRows), Setter = value => context.CsvIgnoreInvalidRows = bool.Parse(value), Getter = () => context.CsvIgnoreInvalidRows.ToString(), Description = "Ignore CSV rows that can't be parsed"},
                 new Option {Key = nameof(context.CsvRealign), Setter = value => context.CsvRealign = bool.Parse(value), Getter = () => context.CsvRealign.ToString(), Description = $"Realign imported CSV points to the /{nameof(context.StartTime)} value"},
+                new Option {Key = "CsvFormat", Description = "Shortcut for known CSV formats. One of 'NG' or '3X'. [default: NG]", Setter =
+                    value =>
+                    {
+                        if (value.Equals("Ng", StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            SetNgCsvFormat(context);
+                        }
+                        else if (value.Equals("3x", StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            Set3XCsvFormat(context);
+                        }
+                        else
+                        {
+                            throw new ExpectedException($"'{value}' is an unknown CSV format.");
+                        }
+                    }}, 
             };
 
             var usageMessage
@@ -133,7 +158,7 @@ namespace PointZilla
                       + $"\n"
                       + $"\nusage: {GetProgramName()} [-option=value] [@optionsFile] [command] [identifierOrGuid] [value] [csvFile] ..."
                       + $"\n"
-                      + $"\nSupported -option=value settings (/option=value works too):\n\n  -{string.Join("\n  -", options.Select(o => o.UsageText()))}"
+                      + $"\nSupported -option=value settings (/option=value works too):\n\n  {string.Join("\n  ", options.Select(o => o.UsageText()))}"
                       + $"\n"
                       + $"\nUse the @optionsFile syntax to read more options from a file."
                       + $"\n"
@@ -192,7 +217,7 @@ namespace PointZilla
                 var value = match.Groups["value"].Value;
 
                 var option =
-                    options.FirstOrDefault(o => o.Key.Equals(key, StringComparison.InvariantCultureIgnoreCase));
+                    options.FirstOrDefault(o => o.Key != null && o.Key.Equals(key, StringComparison.InvariantCultureIgnoreCase));
 
                 if (option == null)
                 {
@@ -229,6 +254,73 @@ namespace PointZilla
                 .Where(s => !s.StartsWith("#") && !s.StartsWith("//"));
         }
 
+        private static void SetNgCsvFormat(Context context)
+        {
+            // Match AQTS 201x Export-from-Springboard CSV format
+
+            // # Take Volume.CS1004@IM974363.EntireRecord.csv generated at 2018-09-14 05:03:15 (UTC-07:00) by AQUARIUS 18.3.79.0
+            // # 
+            // # Time series identifier: Take Volume.CS1004@IM974363
+            // # Location: 20017_CS1004
+            // # UTC offset: (UTC+12:00)
+            // # Value units: m^3
+            // # Value parameter: Take Volume
+            // # Interpolation type: Instantaneous Totals
+            // # Time series type: Basic
+            // # 
+            // # Export options: Corrected signal from Beginning of Record to End of Record
+            // # 
+            // # CSV data starts at line 15.
+            // # 
+            // ISO 8601 UTC, Timestamp (UTC+12:00), Value, Approval Level, Grade, Qualifiers
+            // 2013-07-01T11:59:59Z,2013-07-01 23:59:59,966.15,Raw - yet to be review,200,
+            // 2013-07-02T11:59:59Z,2013-07-02 23:59:59,966.15,Raw - yet to be review,200,
+            // 2013-07-03T11:59:59Z,2013-07-03 23:59:59,966.15,Raw - yet to be review,200,
+
+            context.CsvTimeField = 1;
+            context.CsvValueField = 3;
+            context.CsvGradeField = 5;
+            context.CsvQualifiersField = 6;
+            context.CsvComment = "#";
+            context.CsvSkipRows = 0;
+            context.CsvTimeFormat = null;
+            context.CsvIgnoreInvalidRows = true;
+            context.CsvRealign = false;
+        }
+
+        private static void Set3XCsvFormat(Context context)
+        {
+            // Match AQTS 3.x Export format
+
+            // ,Take Volume.CS1004@IM974363,Take Volume.CS1004@IM974363,Take Volume.CS1004@IM974363,Take Volume.CS1004@IM974363
+            // mm/dd/yyyy HH:MM:SS,m^3,,,
+            // Date-Time,Value,Grade,Approval,Interpolation Code
+            // 07/01/2013 23:59:59,966.15,200,1,6
+            // 07/02/2013 23:59:59,966.15,200,1,6
+
+            context.CsvTimeField = 1;
+            context.CsvValueField = 2;
+            context.CsvGradeField = 3;
+            context.CsvQualifiersField = 0;
+            context.CsvComment = null;
+            context.CsvSkipRows = 2;
+            context.CsvTimeFormat = "MM/dd/yyyy HH:mm:ss";
+            context.CsvIgnoreInvalidRows = true;
+            context.CsvRealign = false;
+        }
+
+        private static TEnum ParseEnum<TEnum>(string value) where TEnum : struct
+        {
+            if (Enum.TryParse<TEnum>(value, true, out var enumValue))
+                return enumValue;
+
+            throw new ExpectedException($"'{value}' is not a valid {typeof(TEnum).Name} value.");
+        }
+
+        private static string EnumOptions<TEnum>() where TEnum : struct
+        {
+            return $"One of {string.Join(", ", Enum.GetNames(typeof(TEnum)))}.";
+        }
 
         private static void ParseManualPoints(Context context, double numericValue)
         {

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/Readme.md
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/Readme.md
@@ -86,7 +86,15 @@ $ ./PointZilla.exe -server=myserver Stage.Label@MyLocation 12.5
 
 `PointZilla` can also read times, values, grade codes, and qualifiers from a CSV file.
 
-All the CSV parsing options are configurable, but will default to values which match the CSV files exported from AQTS Springboard.
+All the CSV parsing options are configurable, but will default to values which match the CSV files exported from AQTS Springboard from 201x systems.
+
+The `-csvFormat=` option supports two prefconfigured formats:
+
+- `-csvFormat=NG` is equivalent to `-csvTimeField=1 -csvValueField=3 -csvGradeField=5 -csvQualifiersField=6 -csvSkipRows=0 -csvComment="#"`
+- `-csvFormat=3X` is equivalent to `-csvTimeField=1 -csvValueField=2 -csvGradeField=3 -csvQualifiersField=0 -csvSkipRows=2 -csvTimeFormat="MM/dd/yyyy HH:mm:ss"`
+
+
+
 
 ```sh
 $ ./PointZilla.exe -server=myserver Stage.Label@MyLocation Downloads/Stage.Historical@A001002.EntireRecord.csv
@@ -100,7 +108,7 @@ $ ./PointZilla.exe -server=myserver Stage.Label@MyLocation Downloads/Stage.Histo
 Parsing CSV files exported from AQTS 3.X systems requires a different CSV parsing configuration.
 
 ```sh
-$ ./PointZilla.exe -server=myserver Stage.Label@MyLocation Downloads/ExportedFrom3x.csv -csvTimeField=1 -csvValueField=2 -csvGradeField=3 -csvQualifiersField=0 -csvSkipRows=2 -csvTimeFormat="MM/dd/yyyy HH:mm:ss"
+$ ./PointZilla.exe -server=myserver Stage.Label@MyLocation Downloads/ExportedFrom3x.csv -csvFormat=3x
 
 13:45:49.400 INFO  - Loaded 250 points from 'Downloads/ExportedFrom3x.csv'.
 13:45:49.745 INFO  - Connected to myserver (2017.4.79.0)
@@ -113,6 +121,15 @@ $ ./PointZilla.exe -server=myserver Stage.Label@MyLocation Downloads/ExportedFro
 When `/CsvRealign=true` is set, all the imported CSV rows will be realigned to the `/StartTime` option.
 
 This option can be a useful technique to "stitch together" a simulated signal with special shapes at specific times.
+
+## Creating missing time-series or locations (Use with caution!)
+
+By default (the `/CreateMode=Never` option), trying to append points to a non-existent time-series will quickly return an error.
+
+The `/CreateMode=Basic` and `/CreateMode=Reflected` options can be used to quickly create a missing time-series if necessary.
+When time-series creation is enabled, a location will also be created if needed.
+
+This mode is useful for testing, but is not recommended for production systems, since the default configurations chosen by PointZilla are likely not correct.
 
 ## Appending grades and qualifiers
 

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/TimeSeriesCreator.cs
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/TimeSeriesCreator.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Aquarius.TimeSeries.Client;
+using Aquarius.TimeSeries.Client.Helpers;
+using Aquarius.TimeSeries.Client.ServiceModels.Provisioning;
+using Aquarius.TimeSeries.Client.ServiceModels.Publish;
+using NodaTime;
+using ServiceStack.Logging;
+using InterpolationType = Aquarius.TimeSeries.Client.ServiceModels.Provisioning.InterpolationType;
+
+namespace PointZilla
+{
+    public class TimeSeriesCreator
+    {
+        private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        public Context Context { get; set; }
+        public IAquariusClient Client { get; set; }
+
+        public void CreateMissingTimeSeries(string timeSeriesIdentifier)
+        {
+            var locationIdentifier = TimeSeriesIdentifierParser.ParseLocationIdentifier(timeSeriesIdentifier);
+
+            var location = GetOrCreateLocation(locationIdentifier);
+
+            GetOrCreateTimeSeries(location, timeSeriesIdentifier);
+        }
+
+        private Location GetOrCreateLocation(string locationIdentifier)
+        {
+            var locationDescription = Client.Publish.Get(new LocationDescriptionListServiceRequest
+                    {LocationIdentifier = locationIdentifier})
+                .LocationDescriptions
+                .SingleOrDefault();
+
+            return locationDescription == null
+                ? CreateLocation(locationIdentifier)
+                : Client.Provisioning.Get(new GetLocation {LocationUniqueId = locationDescription.UniqueId});
+        }
+
+        private Location CreateLocation(string locationIdentifier)
+        {
+            var locationTypes = Client.Provisioning.Get(new GetLocationTypes())
+                .Results;
+
+            var locationType = locationTypes.FirstOrDefault(lt => lt.TypeName.Contains("Hydro"))
+                               ?? locationTypes.First();
+
+            var locationFolder = Client.Provisioning.Get(new GetLocationFolders())
+                .Results
+                .First(lf => !lf.ParentLocationFolderUniqueId.HasValue);
+
+            var request = new PostLocation
+            {
+                LocationType = locationType.TypeName,
+                LocationIdentifier = locationIdentifier,
+                LocationName = $"PointZilla-{locationIdentifier}",
+                Description = "Dummy location created by PointZilla",
+                LocationPath = locationFolder.LocationFolderPath,
+                UtcOffset = Context.UtcOffset ?? Offset.FromTicks(DateTimeOffset.Now.Offset.Ticks),
+                ExtendedAttributeValues = GetDefaultExtendedAttributes(locationType.ExtendedAttributeFields).ToList()
+            };
+
+            Log.Info($"Creating location '{locationIdentifier}' ...");
+
+            return Client.Provisioning.Post(request);
+        }
+
+        private void GetOrCreateTimeSeries(Location location, string timeSeriesIdentifier)
+        {
+            var existingTimeSeries = Client.Provisioning.Get(new GetLocationTimeSeries {LocationUniqueId = location.UniqueId})
+                .Results
+                .FirstOrDefault(ts => ts.Identifier == timeSeriesIdentifier);
+
+            if (existingTimeSeries != null)
+                return;
+
+            var timeSeriesExtendedAttributes = Client.Provisioning.Get(new GetTimeSeriesExtendedAttributes())
+                .Results;
+
+            var timeSeriesInfo = TimeSeriesIdentifierParser.ParseExtendedIdentifier(timeSeriesIdentifier);
+
+            var parameter = Client.Provisioning.Get(new GetParameters())
+                .Results
+                .FirstOrDefault(p => p.Identifier.Equals(timeSeriesInfo.Parameter, StringComparison.InvariantCultureIgnoreCase));
+
+            if (parameter == null)
+                throw new ExpectedException($"Parameter '{timeSeriesInfo.Parameter}' does not exist in the system.");
+
+            var gapTolerance = InterpolationTypesWithNoGaps.Contains(parameter.InterpolationType)
+                ? DurationExtensions.MaxGapDuration
+                : Context.GapTolerance;
+
+            var defaultMonitoringMethod = Client.Provisioning.Get(new GetMonitoringMethods())
+                .Results
+                .Single(monitoringMethod => monitoringMethod.ParameterUniqueId == Guid.Empty);
+
+            PostBasicTimeSeries basicTimeSeries = null;
+            PostReflectedTimeSeries reflectedTimeSeries = null;
+            TimeSeriesBase request;
+
+            if (Context.CreateMode == CreateMode.Reflected)
+            {
+                reflectedTimeSeries = new PostReflectedTimeSeries { GapTolerance = gapTolerance };
+                request = reflectedTimeSeries;
+            }
+            else
+            {
+                basicTimeSeries = new PostBasicTimeSeries {GapTolerance = gapTolerance};
+                request = basicTimeSeries;
+            }
+
+            request.LocationUniqueId = location.UniqueId;
+            request.UtcOffset = location.UtcOffset;
+            request.Label = timeSeriesInfo.Label;
+            request.Parameter = parameter.ParameterId;
+            request.Description = "Created by PointZilla";
+            request.ExtendedAttributeValues = GetDefaultExtendedAttributes(timeSeriesExtendedAttributes).ToList();
+            request.Unit = parameter.UnitIdentifier;
+            request.InterpolationType = parameter.InterpolationType;
+            request.Method = defaultMonitoringMethod.MethodCode;
+
+            Log.Info($"Creating '{timeSeriesIdentifier}' time-series ...");
+
+            var timeSeries = Context.CreateMode == CreateMode.Reflected
+                ? Client.Provisioning.Post(reflectedTimeSeries)
+                : Client.Provisioning.Post(basicTimeSeries);
+
+            Log.Info($"Created '{timeSeries.Identifier}' ({timeSeries.TimeSeriesType}) successfully.");
+        }
+
+        private static readonly InterpolationType[] InterpolationTypesWithNoGaps =
+        {
+            InterpolationType.PrecedingTotals,
+            InterpolationType.InstantaneousTotals,
+            InterpolationType.DiscreteValues,
+        };
+
+        private static IEnumerable<ExtendedAttributeValue> GetDefaultExtendedAttributes(IList<ExtendedAttributeField> extendedAttributeFields)
+        {
+            return extendedAttributeFields
+                .Where(f => !f.CanBeEmpty)
+                .Select(CreateDefaultValue);
+        }
+
+        private static ExtendedAttributeValue CreateDefaultValue(ExtendedAttributeField field)
+        {
+            return new ExtendedAttributeValue
+            {
+                ColumnIdentifier = field.ColumnIdentifier,
+                Value = DefaultValues[field.FieldType](field)
+            };
+        }
+
+        private static readonly Dictionary<ExtendedAttributeFieldType, Func<ExtendedAttributeField, string>>
+            DefaultValues = new Dictionary<ExtendedAttributeFieldType, Func<ExtendedAttributeField, string>>
+            {
+                {ExtendedAttributeFieldType.Boolean, field => default(bool).ToString()},
+                {ExtendedAttributeFieldType.Number, field => "0"},
+                {ExtendedAttributeFieldType.DateTime, field => DateTimeOffset.UtcNow.ToString("O")},
+                {ExtendedAttributeFieldType.String, field => string.Empty},
+                {ExtendedAttributeFieldType.StringOption, field => field.ValueOptions.First()},
+            };
+    }
+}

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/TimeSeriesIdentifier.cs
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/TimeSeriesIdentifier.cs
@@ -8,6 +8,9 @@ namespace PointZilla
         public string Username { get; set; }
         public string Password { get; set; }
         public string Identifier { get; set; }
+        public string Parameter { get; set; }
+        public string Label { get; set; }
+        public string LocationIdentifier { get; set; }
 
         public static bool TryParse(string text, out TimeSeriesIdentifier timeSeriesIdentifier)
         {

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/TimeSeriesIdentifierParser.cs
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/TimeSeriesIdentifierParser.cs
@@ -29,6 +29,9 @@ namespace PointZilla
                 Username = match.Groups["username"].Value,
                 Password = match.Groups["password"].Value,
                 Identifier = match.Groups["identifier"].Value,
+                Parameter = match.Groups["parameter"].Value,
+                Label = match.Groups["label"].Value,
+                LocationIdentifier = match.Groups["location"].Value
             };
         }
     }


### PR DESCRIPTION
1) Added CSV format shortcuts for NG and 3X export formats

This allows you to easily consume exports from other systems.

2) Added -CreateMode support

Defaults to Never, but supports Basic and Reflected time-series creation when needed.
If required, the location will also be created to contain the newly created time-series.