### PR TITLE
Issue-73 Batch large appends

### DIFF
--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/Context.cs
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/Context.cs
@@ -34,6 +34,7 @@ namespace PointZilla
         public Instant StartTime { get; set; } = Instant.FromDateTimeUtc(DateTime.UtcNow);
         public TimeSpan PointInterval { get; set; } = TimeSpan.FromMinutes(1);
         public int NumberOfPoints { get; set; } // 0 means "derive the point count from number of periods"
+        public int BatchSize { get; set; } = 500_000;
         public double NumberOfPeriods { get; set; } = 1;
         public WaveformType WaveformType { get; set; } = WaveformType.SineWave;
         public double WaveformOffset { get; set; } = 0;

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/PointsAppender.cs
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/PointsAppender.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using System.Security;
 using Aquarius.TimeSeries.Client;
 using Aquarius.TimeSeries.Client.ServiceModels.Acquisition;
 using Aquarius.TimeSeries.Client.ServiceModels.Provisioning;
@@ -71,7 +70,7 @@ namespace PointZilla
                     var result = AppendPointBatch(client, timeSeries, batch.Item1, batch.Item2, isReflected, hasTimeRange);
                     numberOfPointsAppended += result.NumberOfPointsAppended;
                     numberOfPointsDeleted += result.NumberOfPointsDeleted;
-                    batchCount += 1;
+                    batchCount++;
 
                     if (result.AppendStatus != AppendStatusCode.Completed)
                         throw new ExpectedException($"Unexpected append status={result.AppendStatus}");

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/PointsAppender.cs
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/PointsAppender.cs
@@ -63,6 +63,7 @@ namespace PointZilla
 
                 var numberOfPointsAppended = 0;
                 var numberOfPointsDeleted = 0;
+                var batchCount = 0;
                 var stopwatch = Stopwatch.StartNew();
 
                 foreach (var batch in GetPointBatches())
@@ -70,12 +71,14 @@ namespace PointZilla
                     var result = AppendPointBatch(client, timeSeries, batch.Item1, batch.Item2, isReflected, hasTimeRange);
                     numberOfPointsAppended += result.NumberOfPointsAppended;
                     numberOfPointsDeleted += result.NumberOfPointsDeleted;
+                    batchCount += 1;
 
                     if (result.AppendStatus != AppendStatusCode.Completed)
                         throw new ExpectedException($"Unexpected append status={result.AppendStatus}");
                 }
 
-                Log.Info($"Appended {numberOfPointsAppended} points (deleting {numberOfPointsDeleted} points) in {stopwatch.ElapsedMilliseconds / 1000.0:F1} seconds.");
+                var batchText = batchCount > 1 ? $" using {batchCount} appends" : "";
+                Log.Info($"Appended {numberOfPointsAppended} points (deleting {numberOfPointsDeleted} points) in {stopwatch.ElapsedMilliseconds / 1000.0:F1} seconds{batchText}.");
             }
         }
 

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/Program.cs
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/Program.cs
@@ -97,6 +97,7 @@ namespace PointZilla
 
                 new Option {Key = nameof(context.Wait), Setter = value => context.Wait = bool.Parse(value), Getter = () => context.Wait.ToString(), Description = "Wait for the append request to complete"},
                 new Option {Key = nameof(context.AppendTimeout), Setter = value => context.AppendTimeout = TimeSpan.Parse(value), Getter = () => context.AppendTimeout.ToString(), Description = "Timeout period for append completion, in .NET TimeSpan format."},
+                new Option {Key = nameof(context.BatchSize), Setter = value => context.BatchSize = int.Parse(value), Getter = () => context.BatchSize.ToString(), Description = "Maximum number of points to send in a single append request"},
 
                 new Option(), new Option {Description = "Time-series options:"},
                 new Option {Key = nameof(context.TimeSeries), Setter = value => context.TimeSeries = value, Getter = () => context.TimeSeries, Description = "Target time-series identifier or unique ID"},


### PR DESCRIPTION
This allows PointZilla to break up very large sets of points and send it in sequential batches. In my testing, I found a batch size of 500k a little easier to test, so I am not quite meeting the requirement of Issue #73...
