### PR TITLE
Issue-91 Allow a time-series with locked approval regions to be deleted.

### DIFF
--- a/TimeSeries/PublicApis/SdkExamples/LocationDeleter/PrivateApis.cs
+++ b/TimeSeries/PublicApis/SdkExamples/LocationDeleter/PrivateApis.cs
@@ -66,6 +66,100 @@ namespace LocationDeleter.PrivateApis
         {
             public long Id { get; set; }
         }
+
+        // Approval DTOs lifted from 17.3 SiteVisit and trimmed down to minimum required properties
+        [Route("/locations/{Id}/approvallevels", HttpMethods.Get)]
+        public class GetLocationApprovalLevels : IReturn<ResolvedLocationRole>
+        {
+            public long Id { get; set; }
+        }
+
+        public class ResolvedLocationRole
+        {
+            public string Name { get; set; }
+            public bool IsLocationVisible { get; set; }
+            public bool CanEditLocationDetails { get; set; }
+            public bool CanAssignUserRoles { get; set; }
+            public bool CanReadData { get; set; }
+            public bool CanAddData { get; set; }
+            public bool CanEditData { get; set; }
+            public bool CanAddOrRemoveLocations { get; set; }
+            public bool CanRemoveFieldVisits { get; set; }
+
+            public List<ApprovalLevel> ApprovalLevels { get; set; }
+            public List<ApprovalTransition> AllowedTransitions { get; set; }
+        }
+
+        public class ApprovalLevel
+        {
+            public long Id { get; set; }
+
+            public long Level { get; set; }
+
+            public string Name { get; set; }
+
+            public string HexColor { get; set; }
+        }
+
+        public class ApprovalTransition
+        {
+            public long FromApprovalLevelId { get; set; }
+            public long ToApprovalLevelId { get; set; }
+        }
+
+        [Route("/datasets/{Id}/approval", HttpMethods.Post)]
+        public class PostDatasetApproval : IReturn<DatasetApprovalSaveResult>
+        {
+            public long Id { get; set; }
+            public bool IsMigrationRequest { get; set; }
+            public long ApprovalLevelId { get; set; }
+        }
+
+        [Route("/approvaljobs/{Id}", HttpMethods.Get)]
+        public class GetApprovalJob : IReturn<DatasetApprovalSaveResult>
+        {
+            public Int64 Id { get; set; }
+        }
+
+        public class DatasetApprovalSaveResult
+        {
+            public Int64 Id { get; set; }
+            public bool Complete { get; set; }
+            public bool Success { get; set; }
+            public List<RelatedDataset> RelatedDatasets { get; set; }
+        }
+
+        public class RelatedDataset
+        {
+            public int Order { get; set; }
+            public Dataset Dataset { get; set; }
+            public bool IsMinimumRequired { get; set; }
+            public bool IsApprovalChangeRequired { get; set; }
+            public List<string> ApprovalRejectionReasons { get; set; }
+        }
+
+        public class Dataset
+        {
+            public long Id { get; set; }
+            public long LocationId { get; set; }
+            public string Identifier { get; set; }
+            public string FullIdentifier { get; set; }
+            public string LocationIdentifier { get; set; }
+            public string LocationName { get; set; }
+            public string SubLocationIdentifier { get; set; }
+            public string Label { get; set; }
+            public string Description { get; set; }
+            public string ParameterId { get; set; }
+            public string ParameterName { get; set; }
+            public string UnitId { get; set; }
+            public string UnitDisplayName { get; set; }
+            public DateTime LastModified { get; set; }
+            public bool Publish { get; set; }
+            public long UtcOffsetMinutes { get; set; }
+            public bool IsActive { get; set; }
+            public string ComputationDisplayName { get; set; }
+            public string ComputationPeriodDisplayName { get; set; }
+        }
     }
 
     namespace Processor


### PR DESCRIPTION
If a time-series delete request fails because the time-series has locked approval regions, prompt the user if they really want to delete the time-series anyways.

If confirmed, unlock the entire time-series by setting it to the lowest approval level.
Then try deleting it again.