### PR TITLE
Issue-94 Added more command line options for time-series creation

### DIFF
--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/Context.cs
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/Context.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Aquarius.TimeSeries.Client.Helpers;
 using Aquarius.TimeSeries.Client.ServiceModels.Acquisition;
+using Aquarius.TimeSeries.Client.ServiceModels.Provisioning;
 using NodaTime;
 
 namespace PointZilla
@@ -24,6 +25,16 @@ namespace PointZilla
         public CreateMode CreateMode { get; set; } = CreateMode.Never;
         public Duration GapTolerance { get; set; } = DurationExtensions.MaxGapDuration;
         public Offset? UtcOffset { get; set; }
+        public string Unit { get; set; }
+        public InterpolationType? InterpolationType { get; set; }
+        public bool Publish { get; set; }
+        public string Description { get; set; } = "Created by PointZilla";
+        public string Comment { get; set; }
+        public string Method { get; set; }
+        public string ComputationIdentifier { get; set; }
+        public string ComputationPeriodIdentifier { get; set; }
+        public string SubLocationIdentifier { get; set; }
+        public List<ExtendedAttributeValue> ExtendedAttributeValues { get; set; } = new List<ExtendedAttributeValue>();
 
         public TimeSeriesIdentifier SourceTimeSeries { get; set; }
         public Instant? SourceQueryFrom { get; set; }

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/ExternalPointsReader.cs
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/ExternalPointsReader.cs
@@ -3,11 +3,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Aquarius.TimeSeries.Client;
+using Aquarius.TimeSeries.Client.Helpers;
 using Aquarius.TimeSeries.Client.ServiceModels.Acquisition;
+using Aquarius.TimeSeries.Client.ServiceModels.Provisioning;
 using Aquarius.TimeSeries.Client.ServiceModels.Publish;
 using Get3xCorrectedData = Aquarius.TimeSeries.Client.ServiceModels.Legacy.Publish3x.TimeSeriesDataCorrectedServiceRequest;
+using Get3xTimeSeriesDescription = Aquarius.TimeSeries.Client.ServiceModels.Legacy.Publish3x.TimeSeriesDescriptionServiceRequest;
 using NodaTime;
 using ServiceStack.Logging;
+using InterpolationType = Aquarius.TimeSeries.Client.ServiceModels.Provisioning.InterpolationType;
 
 namespace PointZilla
 {
@@ -44,29 +48,106 @@ namespace PointZilla
         {
             var timeSeriesInfo = client.GetTimeSeriesInfo(Context.SourceTimeSeries.Identifier);
 
-            var points = client.Publish.Get(new TimeAlignedDataServiceRequest
-                {
-                    TimeSeriesUniqueIds = new List<Guid> { timeSeriesInfo.UniqueId },
-                    QueryFrom = Context.SourceQueryFrom?.ToDateTimeOffset(),
-                    QueryTo = Context.SourceQueryTo?.ToDateTimeOffset()
-                })
+            var timeSeriesData = client.Publish.Get(new TimeSeriesDataCorrectedServiceRequest
+            {
+                TimeSeriesUniqueId = timeSeriesInfo.UniqueId,
+                QueryFrom = Context.SourceQueryFrom?.ToDateTimeOffset(),
+                QueryTo = Context.SourceQueryTo?.ToDateTimeOffset()
+            });
+
+            var points = timeSeriesData
                 .Points
                 .Select(p => new ReflectedTimeSeriesPoint
                 {
-                    Time = Instant.FromDateTimeOffset(p.Timestamp),
-                    Value = p.NumericValue1,
-                    GradeCode = p.GradeCode1.HasValue ? (int)p.GradeCode1 : (int?)null,
-                    Qualifiers = QualifiersParser.Parse(p.Qualifiers1)
+                    Time = Instant.FromDateTimeOffset(p.Timestamp.DateTimeOffset),
+                    Value = p.Value.Numeric,
+                    GradeCode = GetFirstMetadata(timeSeriesData.Grades, p.Timestamp.DateTimeOffset, g => int.Parse(g.GradeCode)),
+                    Qualifiers = GetManyMetadata(timeSeriesData.Qualifiers, p.Timestamp.DateTimeOffset, q => q.Identifier).ToList()
                 })
                 .ToList();
+
+            var gapToleranceInMinutes = timeSeriesData.GapTolerances.Last().ToleranceInMinutes;
+            var gapTolerance = gapToleranceInMinutes.HasValue
+                ? Duration.FromMinutes((long) gapToleranceInMinutes.Value)
+                : DurationExtensions.MaxGapDuration;
+            var interpolationType = (InterpolationType) Enum.Parse(typeof(InterpolationType), timeSeriesData.InterpolationTypes.Last().Type, true);
+
+            SetTimeSeriesCreationProperties(
+                timeSeriesInfo,
+                timeSeriesInfo.UtcOffset,
+                timeSeriesData.Methods.LastOrDefault()?.MethodCode,
+                gapTolerance,
+                interpolationType);
 
             Log.Info($"Loaded {points.Count} points from {timeSeriesInfo.Identifier}");
 
             return points;
         }
 
+        private static T GetFirstMetadata<TMetadata, T>(IEnumerable<TMetadata> items, DateTimeOffset time, Func<TMetadata,T> func)
+            where TMetadata : TimeRange
+        {
+            var metadata = items.FirstOrDefault(i => i.StartTime <= time && time < i.EndTime);
+
+            return metadata == null ? default(T) : func(metadata);
+        }
+
+        private static IEnumerable<T> GetManyMetadata<TMetadata, T>(IEnumerable<TMetadata> items, DateTimeOffset time, Func<TMetadata, T> func)
+            where TMetadata : TimeRange
+        {
+            return items
+                .Where(i => i.StartTime <= time && time < i.EndTime)
+                .Select(func);
+        }
+
+        private void SetTimeSeriesCreationProperties(
+            TimeSeries timeSeries,
+            Offset? utcOffset = null,
+            string method = null,
+            Duration? gapTolerance = null,
+            InterpolationType? interpolationType = null)
+        {
+            if (gapTolerance.HasValue)
+                Context.GapTolerance = gapTolerance.Value;
+
+            if (interpolationType.HasValue && !Context.InterpolationType.HasValue)
+                Context.InterpolationType = interpolationType;
+
+            if (utcOffset.HasValue && !Context.UtcOffset.HasValue)
+                Context.UtcOffset = utcOffset.Value;
+
+            Context.Publish = timeSeries.Publish;
+            Context.Description = timeSeries.Description;
+
+            Context.Method = Context.Method ?? method;
+            Context.Unit = Context.Unit ?? timeSeries.Unit;
+            Context.Comment = Context.Comment ?? timeSeries.Comment;
+            Context.ComputationIdentifier = Context.ComputationIdentifier ?? timeSeries.ComputationIdentifier;
+            Context.ComputationPeriodIdentifier = Context.ComputationPeriodIdentifier ?? timeSeries.ComputationPeriodIdentifier;
+            Context.SubLocationIdentifier = Context.SubLocationIdentifier ?? timeSeries.SubLocationIdentifier;
+
+            foreach (var extendedAttributeValue in timeSeries.ExtendedAttributeValues)
+            {
+                if (Context.ExtendedAttributeValues.Any(a => a.ColumnIdentifier == extendedAttributeValue.ColumnIdentifier))
+                    continue;
+
+                Context.ExtendedAttributeValues.Add(extendedAttributeValue);
+            }
+        }
+
         private List<ReflectedTimeSeriesPoint> LoadPointsFrom3X(IAquariusClient client)
         {
+            var timeSeriesDescription = client.Publish.Get(new Get3xTimeSeriesDescription
+                {
+                    LocationIdentifier = Context.SourceTimeSeries.LocationIdentifier,
+                    Parameter = Context.SourceTimeSeries.Parameter
+                })
+                .TimeSeriesDescriptions
+                .SingleOrDefault(ts => ts.Identifier == Context.SourceTimeSeries.Identifier);
+
+            if (timeSeriesDescription == null)
+                throw new ExpectedException($"Can't find '{Context.SourceTimeSeries.Identifier}' time-series in location '{Context.SourceTimeSeries.LocationIdentifier}'.");
+
             var points = client.Publish.Get(new Get3xCorrectedData
                 {
                     TimeSeriesIdentifier = Context.SourceTimeSeries.Identifier,
@@ -81,6 +162,27 @@ namespace PointZilla
                     GradeCode = p.Grade
                 })
                 .ToList();
+
+            SetTimeSeriesCreationProperties(new TimeSeries
+            {
+                Parameter = timeSeriesDescription.Parameter,
+                Label = timeSeriesDescription.Label,
+                Unit = timeSeriesDescription.Unit,
+                Publish = timeSeriesDescription.Publish,
+                Description = timeSeriesDescription.Description,
+                Comment = timeSeriesDescription.Comment,
+                ComputationIdentifier = timeSeriesDescription.ComputationIdentifier,
+                ComputationPeriodIdentifier = timeSeriesDescription.ComputationPeriodIdentifier,
+                SubLocationIdentifier = timeSeriesDescription.SubLocationIdentifier,
+                LocationIdentifier = timeSeriesDescription.LocationIdentifier,
+                ExtendedAttributeValues = timeSeriesDescription.ExtendedAttributes.Select(ea =>
+                        new ExtendedAttributeValue
+                        {
+                            ColumnIdentifier = $"{ea.Name.ToUpperInvariant()}@TIMESERIES_EXTENSION",
+                            Value = ea.Value.ToString()
+                        })
+                    .ToList()
+            });
 
             Log.Info($"Loaded {points.Count} points from {Context.SourceTimeSeries.Identifier}");
 

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/PointZilla.csproj
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/PointZilla.csproj
@@ -16,7 +16,7 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -24,15 +24,17 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Aquarius.Client, Version=18.7.4.0, Culture=neutral, processorArchitecture=MSIL">

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/Readme.md
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/Readme.md
@@ -227,9 +227,22 @@ Supported -option=value settings (/option=value works too):
   -Command                  Append operation to perform.  One of Auto, Append, OverwriteAppend, Reflected, DeleteAllPoints. [default: Auto]
   -GradeCode                Optional grade code for all appended points
   -Qualifiers               Optional qualifier list for all appended points
-  -CreateMode               Mode for creating missing time-series.  One of Never, Basic, Reflected. [default: Never]
-  -GapTolerance             Set the gap tolerance for newly-created time-series. [default: "MaxDuration"]
-  -UtcOffset                Set the UTC offset for any created location. [default: Use system timezone]
+
+  ========================= Time-series creation options:
+  -CreateMode               Mode for creating missing time-series. One of Never, Basic, Reflected. [default: Never]
+  -GapTolerance             Gap tolerance for newly-created time-series. [default: "MaxDuration"]
+  -UtcOffset                UTC offset for any created time-series or location. [default: Use system timezone]
+  -Unit                     Time-series unit
+  -InterpolationType        Time-series interpolation type. One of InstantaneousValues, PrecedingConstant, PrecedingTotals, InstantaneousTotals, DiscreteValues, SucceedingConstant.
+  -Publish                  Publish flag. [default: False]
+  -Description              Time-series description [default: Created by PointZilla]
+  -Comment                  Time-series comment
+  -Method                   Time-series monitoring method
+  -ComputationIdentifier    Time-series computation identifier
+  -ComputationPeriodIdentifier Time-series computation period identifier
+  -SubLocationIdentifier    Time-series sub-location identifier
+  -ExtendedAttributeValues  Extended attribute values in UPPERCASE_COLUMN_NAME@UPPERCASE_TABLE_NAME=value syntax. Can be set multiple times.
+
 
   ========================= Copy points from another time-series:
   -SourceTimeSeries         Source time-series to copy. Prefix with [server2] or [server2:username2:password2] to copy from another server


### PR DESCRIPTION
Added ability to set unit, comment, computation and sublocation identifiers, publish flag, and extended attributes when creating a time-series.

When the -SourceTimeSeries option is used, use the source time-series properties as much as possible if a new time-series is being created.

This brings PointZilla closer to cloning the corrected value of a time-series. Some settings are still not a perfect match, so it isn't recommend for officially migrating a time-series. But it is pretty close.

PointZilla is now a 64-bit-only app so it can deal with bigger signals on modern systems.