### PR TITLE
Fix #111 - pass through verify kwarg to requests

### DIFF
--- a/TimeSeries/PublicApis/Python/timeseries_client.py
+++ b/TimeSeries/PublicApis/Python/timeseries_client.py
@@ -1,17 +1,12 @@
 # Sample python code to Public API course
 # Requires python 2.7+
 # Install required dependencies via: $ pip install requests pytz pyrfc3339
-import logging
 
 import requests
 from requests.exceptions import HTTPError
 import pyrfc3339
 from datetime import datetime
 import re
-
-
-logger = logging.getLogger(__name__)
-
 
 
 def create_endpoint(hostname, root_path):

--- a/TimeSeries/PublicApis/Python/timeseries_client.py
+++ b/TimeSeries/PublicApis/Python/timeseries_client.py
@@ -1,12 +1,18 @@
 # Sample python code to Public API course
 # Requires python 2.7+
 # Install required dependencies via: $ pip install requests pytz pyrfc3339
+import logging
 
 import requests
 from requests.exceptions import HTTPError
 import pyrfc3339
 from datetime import datetime
 import re
+
+
+logger = logging.getLogger(__name__)
+
+
 
 def create_endpoint(hostname, root_path):
     prefix = "http://"
@@ -63,24 +69,25 @@ class TimeseriesSession(requests.sessions.Session):
     >>> session.get('/invalidroute') # Raises HTTPError (404)
     """
 
-    def __init__(self, hostname, root_path):
+    def __init__(self, hostname, root_path, verify=True):
         super(TimeseriesSession, self).__init__()
+        self.verify = verify
         self.base_url = create_endpoint(hostname, root_path)
 
     def get(self, url, **kwargs):
-        r = super(TimeseriesSession, self).get(self.base_url + url, **kwargs)
+        r = super(TimeseriesSession, self).get(self.base_url + url, verify=self.verify, **kwargs)
         return response_or_raise(r)
 
     def post(self, url, data=None, json=None, **kwargs):
-        r = super(TimeseriesSession, self).post(self.base_url + url, data, json, **kwargs)
+        r = super(TimeseriesSession, self).post(self.base_url + url, data, json, verify=self.verify, **kwargs)
         return response_or_raise(r)
 
     def put(self, url, data=None, **kwargs):
-        r = super(TimeseriesSession, self).put(self.base_url + url, data, **kwargs)
+        r = super(TimeseriesSession, self).put(self.base_url + url, data, verify=self.verify, **kwargs)
         return response_or_raise(r)
 
     def delete(self, url, **kwargs):
-        r = super(TimeseriesSession, self).delete(self.base_url + url, **kwargs)
+        r = super(TimeseriesSession, self).delete(self.base_url + url, verify=self.verify, **kwargs)
         return response_or_raise(r)
 
     def set_session_token(self, token):
@@ -144,16 +151,16 @@ class timeseries_client:
     >>> # The session will be disconnected now, even if an exception was thrown in the body of the WITH statement.
     """
 
-    def __init__(self, hostname, username, password):
+    def __init__(self, hostname, username, password, verify=True):
         # Create the three endpoint sessions
-        self.publish = TimeseriesSession(hostname, "/AQUARIUS/Publish/v2")
-        self.acquisition = TimeseriesSession(hostname, "/AQUARIUS/Acquisition/v2")
-        self.provisioning = TimeseriesSession(hostname, "/AQUARIUS/Provisioning/v1")
+        self.publish = TimeseriesSession(hostname, "/AQUARIUS/Publish/v2", verify=verify)
+        self.acquisition = TimeseriesSession(hostname, "/AQUARIUS/Acquisition/v2", verify=verify)
+        self.provisioning = TimeseriesSession(hostname, "/AQUARIUS/Provisioning/v1", verify=verify)
         # Authenticate once
         self.connect(username, password)
 
         # Cache the server version
-        versionSession = TimeseriesSession(hostname, "/AQUARIUS/apps/v1")
+        versionSession = TimeseriesSession(hostname, "/AQUARIUS/apps/v1", verify=verify)
         self.serverVersion = versionSession.get('/version').json()["ApiVersion"]
 
     def __enter__(self):


### PR DESCRIPTION
This PR provides the ability to connect to Aquarius servers which do not have properly verified SSL certificates by passing the ``verify=False`` kwarg through to the requests package.

In particular the provisioning API didn't seem to work without HTTPS (didn't look closely at other means of getting around it).