### PR TITLE
Make Python wrapper a proper package (Add setup.py file)

### DIFF
--- a/TimeSeries/PublicApis/Python/setup.py
+++ b/TimeSeries/PublicApis/Python/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup
+
+setup(
+    name="aquarius-timeseries-client",
+    py_modules=["timeseries_client"],
+    version="0.1",
+    description="Python client for Aquarius TimeSeries API",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+    url="https://github.com/AquaticInformatics/Examples",
+    install_requires=(
+        "requests",
+        "pyrfc3339"
+    )
+)


### PR DESCRIPTION
This PR allows the Python wrapper to be installed as a Python package.

At the moment it installs the ``timeseries_client.py`` file as a module ``timeseries_client``. This could be changed to a proper package in a folder with an ``__init__.py`` file, but that's probably not necessary at the moment.

Example installation after cloning the repo:

```cmd
(temp) C:\Program Files (x86)\MISC\kent>pip install -e Examples\TimeSeries\PublicApis\Python
Looking in indexes: https://pypi.org/simple, http://envtelem04:8090/simple/
Obtaining file:///C:/Program%20Files%20%28x86%29/MISC/kent/Examples/TimeSeries/PublicApis/Python
Collecting requests (from aquarius-timeseries-client==0.1)
  Downloading https://files.pythonhosted.org/packages/7d/e3/20f3d364d6c8e5d2353c72a67778eb189176f08e873c9900e10c0287b84b/requests-2.21.0-py2.py3-none-any.whl (57kB)
    100% |████████████████████████████████| 61kB 1.3MB/s
Collecting pyrfc3339 (from aquarius-timeseries-client==0.1)
  Using cached https://files.pythonhosted.org/packages/c1/7a/725f5c16756ec6211b1e7eeac09f469084595513917ea069bc023c40a5e2/pyRFC3339-1.1-py2.py3-none-any.whl
Collecting urllib3<1.25,>=1.21.1 (from requests->aquarius-timeseries-client==0.1)
  Downloading https://files.pythonhosted.org/packages/62/00/ee1d7de624db8ba7090d1226aebefab96a2c71cd5cfa7629d6ad3f61b79e/urllib3-1.24.1-py2.py3-none-any.whl (118kB)
    100% |████████████████████████████████| 122kB 2.6MB/s
Collecting idna<2.9,>=2.5 (from requests->aquarius-timeseries-client==0.1)
  Downloading https://files.pythonhosted.org/packages/14/2c/cd551d81dbe15200be1cf41cd03869a46fe7226e7450af7a6545bfc474c9/idna-2.8-py2.py3-none-any.whl (58kB)
    100% |████████████████████████████████| 61kB 4.4MB/s
Collecting chardet<3.1.0,>=3.0.2 (from requests->aquarius-timeseries-client==0.1)
  Downloading https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl (133kB)
    100% |████████████████████████████████| 143kB 4.5MB/s
Requirement already satisfied: certifi>=2017.4.17 in c:\program files (x86)\misc\envs\temp\lib\site-packages (from requests->aquarius-timeseries-client==0.1) (2018.4.16)
Collecting pytz (from pyrfc3339->aquarius-timeseries-client==0.1)
  Using cached https://files.pythonhosted.org/packages/f8/0e/2365ddc010afb3d79147f1dd544e5ee24bf4ece58ab99b16fbb465ce6dc0/pytz-2018.7-py2.py3-none-any.whl
Installing collected packages: urllib3, idna, chardet, requests, pytz, pyrfc3339, aquarius-timeseries-client
  Running setup.py develop for aquarius-timeseries-client
Successfully installed aquarius-timeseries-client chardet-3.0.4 idna-2.8 pyrfc3339-1.1 pytz-2018.7 requests-2.21.0 urllib3-1.24.1
```

And then to use in Python is the same as before:

```python
>>> from timeseries_client import timeseries_client
>>> ts = timeseries_client(server, user, pwd)
```