### PR TITLE
Issue-115 - Improved logging of the preprocessor

### DIFF
--- a/TimeSeries/PublicApis/SdkExamples/WaterWatchPreProcessor/log4net.config
+++ b/TimeSeries/PublicApis/SdkExamples/WaterWatchPreProcessor/log4net.config
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <log4net>
   <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender" >
+    <threshold value="WARN" />
+    <target value="Console.Error" />
     <layout type="log4net.Layout.PatternLayout">
       <conversionPattern value="%date{HH:mm:ss.fff} %-5level - %message%newline" />
     </layout>
   </appender>
   <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
+    <threshold value="INFO" />
     <file value="WaterWatchPreProcessor.log" />
     <appendToFile value="true" />
     <rollingStyle value="Size" />
-    <maxSizeRollBackups value="20" />
+    <maxSizeRollBackups value="10" />
     <maximumFileSize value="10MB" />
     <countDirection value="1" />
     <staticLogFileName value="true" />


### PR DESCRIPTION
Don't log to StandardOutput at all (leave that stream alone, for pure preprocessor output)

Log WARN+ to StandardError
Log INFO+ to the file

Log measurement summary per sensor and in total.