### PR TITLE
Issue-132 - Try an alternative API if the main location delete API fails

### DIFF
--- a/TimeSeries/PublicApis/SdkExamples/LocationDeleter/Deleter.cs
+++ b/TimeSeries/PublicApis/SdkExamples/LocationDeleter/Deleter.cs
@@ -945,7 +945,7 @@ namespace LocationDeleter
                 }
                 catch (WebServiceException exception)
                 {
-                    if (exception.StatusCode != 400) throw;
+                    if (exception.StatusCode != 400 && exception.StatusCode != 404) throw;
 
                     Log.Warn($"Trying alternative API to delete '{locationInfo.Identifier}' ...");
 


### PR DESCRIPTION
Some location identifiers are giving the delete-by-Identifier request some troubles.

When that server bug is fixed, try one of the other private APIs to keep going.