### PR TITLE
PF-540 - Added the configurable MaximumPointsPerSensor

### DIFF
--- a/TimeSeries/PublicApis/SdkExamples/SosExporter/Context.cs
+++ b/TimeSeries/PublicApis/SdkExamples/SosExporter/Context.cs
@@ -86,6 +86,7 @@ namespace SosExporter
         public bool NeverResync { get; set; }
         public DateTimeOffset? ChangesSince { get; set; }
         public int MaximumPointsPerObservation { get; set; } = 1000;
+        public int MaximumPointsPerSensor { get; set; } = 10000;
         public TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(5);
         public TimeSpan? MaximumPollDuration { get; set; }
         public bool ApplyRounding { get; set; } = true;

--- a/TimeSeries/PublicApis/SdkExamples/SosExporter/Exporter.cs
+++ b/TimeSeries/PublicApis/SdkExamples/SosExporter/Exporter.cs
@@ -635,13 +635,10 @@ namespace SosExporter
                 .Where(p => p.Timestamp.DateTimeOffset >= earliestDayToUpload)
                 .ToList();
 
-            // Limit points at 10K (that will still hold 7 days of 1-minute data)
-            const int maximumExportCount = 10000;
-
-            if (remainingPoints.Count > maximumExportCount)
+            if (remainingPoints.Count > Context.MaximumPointsPerSensor)
             {
                 remainingPoints = remainingPoints
-                    .Skip(remainingPoints.Count - maximumExportCount)
+                    .Skip(remainingPoints.Count - Context.MaximumPointsPerSensor)
                     .ToList();
             }
 

--- a/TimeSeries/PublicApis/SdkExamples/SosExporter/Program.cs
+++ b/TimeSeries/PublicApis/SdkExamples/SosExporter/Program.cs
@@ -309,6 +309,13 @@ namespace SosExporter
                 },
                 new Option
                 {
+                    Key = nameof(context.MaximumPointsPerSensor),
+                    Setter = value => context.MaximumPointsPerSensor = int.Parse(value),
+                    Getter = () => context.MaximumPointsPerSensor.ToString(),
+                    Description = "The maximum number of points uploaded per SOS sensor"
+                },
+                new Option
+                {
                     Key = nameof(context.MaximumPollDuration),
                     Setter = value => context.MaximumPollDuration = TimeSpan.Parse(value, CultureInfo.InvariantCulture),
                     Getter = () => context.MaximumPollDuration?.Humanize(2),

--- a/TimeSeries/PublicApis/SdkExamples/SosExporter/Readme.md
+++ b/TimeSeries/PublicApis/SdkExamples/SosExporter/Readme.md
@@ -218,6 +218,7 @@ Supported -option=value settings (/option=value works too):
   -ChangesSince                The starting changes-since time in ISO 8601 format. Defaults to the saved AQTS global setting value.
   -ApplyRounding               When true, export the rounded point values. [default: True]
   -MaximumPointsPerObservation The maximum number of points per SOS observation [default: 1000]
+  -MaximumPointsPerSensor      The maximum number of points uploaded per SOS sensor [default: 10000]
   -MaximumPollDuration         The maximum duration before polling AQTS for more changes, in hh:mm:ss format. Defaults to the AQTS global setting.
   -Timeout                     The timeout used for all web requests, in hh:mm:ss format. [default: 5 minutes]
   -SosLoginRoute               SOS server login route


### PR DESCRIPTION
This defaults to 10K points, which is good for 7 days of 1-minute data.