### PR TITLE
PF-766 - ObservationExporter fixes

### DIFF
--- a/Samples/DotNetSdk/SamplesObservationExporter/Exporter.cs
+++ b/Samples/DotNetSdk/SamplesObservationExporter/Exporter.cs
@@ -66,7 +66,7 @@ namespace SamplesObservationExporter
 
         private ISamplesClient Connect()
         {
-            Log.Info($"Connecting to {Context.ServerUrl} ...");
+            Log.Info($"{ExeHelper.ExeNameAndVersion} connecting to {Context.ServerUrl} ...");
 
             var client = SamplesClient.CreateConnectedClient(Context.ServerUrl, Context.ApiToken);
 

--- a/Samples/DotNetSdk/SamplesObservationExporter/Program.cs
+++ b/Samples/DotNetSdk/SamplesObservationExporter/Program.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Xml;
 using Aquarius.TimeSeries.Client;
+using Humanizer;
 using log4net;
 using NodaTime;
 using NodaTime.Text;
@@ -96,13 +97,13 @@ namespace SamplesObservationExporter
                 new Option {Key = nameof(context.Overwrite), Setter = value => context.Overwrite = ParseBoolean(value), Getter = () => $"{context.Overwrite}", Description = "Overwrite existing files?"},
                 new Option {Key = nameof(context.UtcOffset), Setter = value => context.UtcOffset = ParseOffset(value), Getter = () => string.Empty, Description = $"UTC offset for output times [default: Use system timezone, currently {context.UtcOffset:m}]"},
 
-                new Option(), new Option{Description = "Cumulative filter options: (ie. AND-ed together)"},
+                new Option(), new Option{Description = "Cumulative filter options: (ie. AND-ed together). Can be set multiple times."},
                 new Option {Key = nameof(context.StartTime), Setter = value => context.StartTime = ParseDateTimeOffset(value), Getter = () => string.Empty, Description = "Include observations after this time."},
                 new Option {Key = nameof(context.EndTime), Setter = value => context.EndTime = ParseDateTimeOffset(value), Getter = () => string.Empty, Description = "Include observations before this time."},
-                new Option {Key = nameof(context.LocationIds), Setter = value => ParseListValues(context.LocationIds, value), Getter = () => string.Empty, Description = "Observations matching these locations."},
-                new Option {Key = nameof(context.AnalyticalGroupIds), Setter = value => ParseListValues(context.AnalyticalGroupIds, value), Getter = () => string.Empty, Description = "Observations matching these analytical groups."},
-                new Option {Key = nameof(context.ObservedPropertyIds), Setter = value => ParseListValues(context.ObservedPropertyIds, value), Getter = () => string.Empty, Description = "Observations matching these observed properties."},
-                new Option {Key = nameof(context.ProjectIds), Setter = value => ParseListValues(context.ProjectIds, value), Getter = () => string.Empty, Description = "Observations matching these projects."},
+                new Option {Key = nameof(context.LocationIds).Singularize(), Setter = value => context.LocationIds.Add(value), Getter = () => string.Empty, Description = "Observations matching these locations."},
+                new Option {Key = nameof(context.AnalyticalGroupIds).Singularize(), Setter = value => context.AnalyticalGroupIds.Add(value), Getter = () => string.Empty, Description = "Observations matching these analytical groups."},
+                new Option {Key = nameof(context.ObservedPropertyIds).Singularize(), Setter = value => context.ObservedPropertyIds.Add(value), Getter = () => string.Empty, Description = "Observations matching these observed properties."},
+                new Option {Key = nameof(context.ProjectIds).Singularize(), Setter = value => context.ProjectIds.Add(value), Getter = () => string.Empty, Description = "Observations matching these projects."},
             };
 
             var usageMessage
@@ -209,14 +210,6 @@ namespace SamplesObservationExporter
                 return result.Value;
 
             throw new ExpectedException($"'{text}' is not a valid UTC offset {result.Exception.Message}");
-        }
-
-        private static void ParseListValues(List<string> items, string text)
-        {
-            items.AddRange(text
-                .Split(',')
-                .Select(s => s.Trim())
-                .Where(s => !string.IsNullOrEmpty(s)));
         }
 
         private readonly Context _context;

--- a/Samples/DotNetSdk/SamplesObservationExporter/Readme.md
+++ b/Samples/DotNetSdk/SamplesObservationExporter/Readme.md
@@ -1,6 +1,6 @@
 ﻿# SamplesObservationExporter
 
-Download the [latest SamplesObservationExporter.exe release here](../../../../../../releases/latest)
+Download the [latest SamplesObservationExporter.exe release here](../../../../../releases/latest)
 
 The `SamplesObservationExporter` tool is a standalone .NET console utility for exporting observed property values from AQUARIUS Samples to a CSV file.
 
@@ -9,6 +9,7 @@ The `SamplesObservationExporter` tool is a standalone .NET console utility for e
 - With no filters specified, all observed values will be exported.
 - Results can be filtered by optional date range, location, project, property, or analytical group.
 - All filters are cumulative (ie. they are AND-ed together). The more filters you add, the fewer results will be exported.
+- An exit code of 0 indicates the export was successful. An exit code greater than 0 indicates an error. This allows for easy error checking when invoked from scripts.
 
 ## Requirements
 
@@ -28,7 +29,7 @@ Try the `/help` option for a detailed list of options and their default values.
 Two options are required to tell the tool how to access your AQUARIUS Samples instance.
 
 - The `/ServerUrl=` option sets the URL to the server, usually something like `/ServerUrl=https://mydomain.aqsamples.com`.
-- The `/ApiToken=` option sets the API token used to authenticate your account. See the online help to determine how to collect your API token.
+- The `/ApiToken=` option sets the API token used to authenticate your account. Navigate to https://[your_account].aqsamples.com/api/ and follow the instructions to get the token.
 
 ### Output options
 
@@ -39,7 +40,7 @@ Two options are required to tell the tool how to access your AQUARIUS Samples in
 ### Filtering observations
 
 - The `/StartTime` and `/EndTime=` options can be used to constrain the matched visits by observation time.
-- The `/LocationIds=`, `/AnalyticalGroupIds=`, `/ObservedPropertyIds=`, and `/ProjectIds=` options can be use to filter by these properties as well.
+- The `/LocationId=`, `/AnalyticalGroupId=`, `/ObservedPropertyId=`, and `/ProjectId=` options can be use to filter by these properties as well. These filters can be specified multiple times.
 - If a supplied filter is invalid (eg. you misspelled the location ID), an error message will be displayed an no export will occur.
 
 ### Examples
@@ -49,7 +50,7 @@ Here we'll just export everthing (this can take a while!):
 ```
 $ SamplesObservationExporter.exe -serverUrl=https://ai.aqsamples.com -apiToken=12345678
 
-17:08:57.436 INFO  - Connecting to https://ai.aqsamples.com ...
+17:08:57.436 INFO  - SamplesObservationExporter (v1.0.0.0) connecting to https://ai.aqsamples.com ...
 17:08:57.945 INFO  - Connected to https://ai.aqsamples.com/api (2020.4.3767) ...
 17:08:58.201 INFO  - Exporting observations  ...
 17:08:58.973 INFO  - Fetching all 18804 matching observations.
@@ -57,24 +58,35 @@ $ SamplesObservationExporter.exe -serverUrl=https://ai.aqsamples.com -apiToken=1
 17:10:32.646 INFO  - Writing observations to 'ExportedObservations-20200827170857.csv' ...
 ```
 
-Here we will only export temperatures during 2019:
+Here we will only export temperatures and mercury measurements from 2019 onward:
 
 ```
-$ SamplesObservationExporter.exe -serverUrl=https://ai.aqsamples.com -apiToken=12345678 -StartTime=2019-01-01 -EndTime=2019-12-31T23:59.59 -ObservationPropertyId=Temperature
+$ SamplesObservationExporter.exe -serverurl=https://ai.aqsamples.com -apitoken=12345678 -StartTime=2019-01-01 -ObservedPropertyId=Temperature -ObservedPropertyId=Mercury
 
-17:18:10.404 INFO  - Connecting to https://ai.aqsamples.com ...
-17:18:10.950 INFO  - Connected to https://ai.aqsamples.com/api (2020.4.3767) ...
-17:18:11.658 INFO  - Exporting observations after 2019-01-01T00:00:00.0000000-08:00 matching before 2019-12-31T23:59:59.0000000-08:00 with observed property 'Temperature' ...
-17:18:12.164 INFO  - Fetching all 3 matching observations.
-17:18:12.182 INFO  - 3 numeric observations loaded in 2 milliseconds.
-17:18:12.193 INFO  - Writing observations to 'C:\git\Examples\Samples\DotNetSdk\SamplesObservationExporter\bin\Debug\ExportedObservations-20200827171810.csv' ...```
+08:40:02.016 INFO  - SamplesObservationExporter (v1.0.0.0) connecting to https://ai.aqsamples.com ...
+08:40:02.518 INFO  - Connected to https://ai.aqsamples.com/api (2020.4.3767) ...
+08:40:03.206 INFO  - Exporting observations after 2019-01-01T00:00:00.0000000-08:00 with 2 observed properties in (Temperature, Mercury) ...
+08:40:03.461 INFO  - Fetching all 5 matching observations.
+08:40:03.469 INFO  - 5 numeric observations loaded in 2 milliseconds.
+08:40:03.481 INFO  - Writing observations to 'ExportedObservations-20200828084002.csv' ...
 ```
 
 ### Output CSV format
 
-- The CSV output is sorted by time, with some common location columns, and with a pair of value and unit columns for each exported property.
+- The CSV output is sorted by time, with some common location columns, and with a pair of value and unit columns for each exported observed property.
+- The more observed  properties exported, the "wider" the CSV file grows. Observed property columns are in sorted order.
 - Some columns will be sparesly populated (empty unit and value columns) if that property was not measured at the time.
 - Non-detects will have an empty value column, and the unit column will show the minimum detection limit, like `< 3 mg/L`.
+
+The CSV for the temperature and mercury export example above looks like this:
+
+```csv
+Lab: Sample ID, Location ID, Observed Date, Observed Time_UTC-07:00, Latitude, Longitude, County, Medium, Location Groups, Mercury_Value, Mercury_mg/L, Temperature_Value, Temperature_Celsius
+, LOC-AL01, 2019-08-03, 04:41:00.000, , , 604, Water, , , , 50, Celsius
+, Doug Location, 2019-12-16, 17:17:00.000, 49.2862766, -123.12306830000001, Kitsilano, Water, , 8, mg/L, 12.34, Celsius
+, Doug Location, 2019-12-16, 17:18:00.000, 49.2862766, -123.12306830000001, Kitsilano, Water, , , , 56.78, Celsius
+, Lake Vancouver, 2020-01-03, 00:00:00.000, , , , Waste Water, , 5, mg/L, ,
+```
 
 ### `/help` screen
 
@@ -94,13 +106,13 @@ Supported -option=value settings (/option=value works too):
   -Overwrite                Overwrite existing files? [default: False]
   -UtcOffset                UTC offset for output times [default: Use system timezone, currently -07:00]
 
-  ========================= Cumulative filter options: (ie. AND-ed together)
+  ========================= Cumulative filter options: (ie. AND-ed together). Can be set multiple times.
   -StartTime                Include observations after this time.
   -EndTime                  Include observations before this time.
-  -LocationIds              Observations matching these locations.
-  -AnalyticalGroupIds       Observations matching these analytical groups.
-  -ObservedPropertyIds      Observations matching these observed properties.
-  -ProjectIds               Observations matching these projects.
+  -LocationId               Observations matching these locations.
+  -AnalyticalGroupId        Observations matching these analytical groups.
+  -ObservedPropertyId       Observations matching these observed properties.
+  -ProjectId                Observations matching these projects.
 
 Use the @optionsFile syntax to read more options from a file.
 

--- a/Samples/DotNetSdk/SamplesObservationExporter/log4net.config
+++ b/Samples/DotNetSdk/SamplesObservationExporter/log4net.config
@@ -7,10 +7,10 @@
   </appender>
   <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
     <file value="SamplesObservationExporter.log" />
-    <appendToFile value="false" />
+    <appendToFile value="true" />
     <rollingStyle value="Size" />
-    <maxSizeRollBackups value="-1" />
-    <maximumFileSize value="10MB" />
+    <maxSizeRollBackups value="30" />
+    <maximumFileSize value="20MB" />
     <countDirection value="1" />
     <staticLogFileName value="true" />
     <layout type="log4net.Layout.PatternLayout">

--- a/Samples/DotNetSdk/SamplesPlannedSpecimenInstantiator/Readme.md
+++ b/Samples/DotNetSdk/SamplesPlannedSpecimenInstantiator/Readme.md
@@ -1,6 +1,6 @@
 ﻿# Samples Planned Specimen Instantiator
 
-Download the [latest SamplesPlannedSpecimenInstantiator.exe release here](../../../../../../releases/latest)
+Download the [latest SamplesPlannedSpecimenInstantiator.exe release here](../../../../../releases/latest)
 
 This Windows GUI tool will:
 


### PR DESCRIPTION
1) Use the singular form of the ID name filters

This will allow for an observed property Id containing a comma, which is common enough.

-ObservedPropertyId="Algae, blue-green density"

2) Made the log4net configuration more sane

3) Improved the readme links a bit