### PR TITLE
PF-782 - Eliminated the .json() ceremony around each API request

### DIFF
--- a/TimeSeries/PublicApis/Python/WindRose/AQTS-WindRose.py
+++ b/TimeSeries/PublicApis/Python/WindRose/AQTS-WindRose.py
@@ -24,7 +24,7 @@ with timeseries_client(config['server'], config['username'], config['password'])
         TimeSeriesOutputUnitIds=['m/s', ''],
         QueryFrom=config['eventPeriodStartDay'],
         QueryTo=config['eventPeriodEndDay']
-    )).json()
+    ))
 
     # Throw the points in a Pandas dataframe
     df = pd.DataFrame(json['Points'])


### PR DESCRIPTION
1) Changed the session methods to implicitly call response.json()

This breaking makes the results much more fluent.

2) Improved the send_batch_requests() helper method

Now it will lookup the metadata route and be a bit more robust if the server-side operation name ever changes.