### PR TITLE
PF-766 - More feedback incorporated

### DIFF
--- a/Samples/DotNetSdk/SamplesObservationExporter/SamplesObservationExporter.csproj
+++ b/Samples/DotNetSdk/SamplesObservationExporter/SamplesObservationExporter.csproj
@@ -48,6 +48,9 @@
     <Reference Include="log4net, Version=2.0.9.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.9\lib\net45\log4net.dll</HintPath>
     </Reference>
+    <Reference Include="MoreLinq, Version=3.3.2.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
+      <HintPath>..\packages\morelinq.3.3.2\lib\net451\MoreLinq.dll</HintPath>
+    </Reference>
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>

--- a/Samples/DotNetSdk/SamplesObservationExporter/packages.config
+++ b/Samples/DotNetSdk/SamplesObservationExporter/packages.config
@@ -9,6 +9,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net472" />
   <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net472" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net472" />
+  <package id="morelinq" version="3.3.2" targetFramework="net472" />
   <package id="NodaTime" version="1.3.0" targetFramework="net472" />
   <package id="ServiceStack.Client" version="5.9.0" targetFramework="net472" />
   <package id="ServiceStack.HttpClient" version="5.9.0" targetFramework="net472" />


### PR DESCRIPTION
1) Use the field visit start time, instead of the observation time

2) Group properties by AnalyticalGroup (if filtered), then by property/unit/method

3) When more than one observed property/unit is exported, add the MethodId to the unit column header

4) Made sure that the CSV is written in Excel-friendly format

Add a UTF-8 byte order mark, so Excel knows how to render any Unicode characters
Remove spaces after each comma, since that space confuses Excel (yikes, that is silly)