### PR TITLE
Updated SOSExporter's docker config to use v4.4.x of SOS

### DIFF
--- a/TimeSeries/PublicApis/SdkExamples/SosExporter/docker/docker-compose/docker-compose.yml
+++ b/TimeSeries/PublicApis/SdkExamples/SosExporter/docker/docker-compose/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=sos
   sos:
-    image: 52north/sos:latest
+    image: 52north/sos:4.4
     expose:
       - "8000"
     links:


### PR DESCRIPTION
The SOS Exporter only works with v4.4.x of 52North's SOS server. Now that 52North has released v5.x as the 'latest' version, things have broken.

Yay! Standards are great!