### PR TITLE
PF-909 - Remove any commas from the Minimum Result Limit

### DIFF
--- a/Samples/DotNetSdk/LabFileImporter/LabFileLoader.cs
+++ b/Samples/DotNetSdk/LabFileImporter/LabFileLoader.cs
@@ -323,7 +323,7 @@ namespace LabFileImporter
             match = NonDetectRegex.Match(text);
 
             if (match.Success)
-                return (null, Context.ResultGrade, match.Groups["number"].Value);
+                return (null, Context.ResultGrade, match.Groups["number"].Value.Replace(",", string.Empty));
 
             return (text, Context.ResultGrade, null);
         }


### PR DESCRIPTION
So the input spreadsheet can contain "> 10,000" but the MRL value imported will be "10000".