### PR TITLE
PF-1084 - PointZilla - Support UrlEncoding of CsvDelimiter option

### DIFF
--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/Program.cs
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/Program.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Web;
 using System.Xml;
 using Aquarius.TimeSeries.Client;
 using Aquarius.TimeSeries.Client.ServiceModels.Acquisition;
@@ -184,7 +185,7 @@ namespace PointZilla
                 new Option {Key = nameof(context.CsvIgnoreInvalidRows), Setter = value => context.CsvIgnoreInvalidRows = bool.Parse(value), Getter = () => context.CsvIgnoreInvalidRows.ToString(), Description = "Ignore CSV rows that can't be parsed"},
                 new Option {Key = nameof(context.CsvRealign), Setter = value => context.CsvRealign = bool.Parse(value), Getter = () => context.CsvRealign.ToString(), Description = $"Realign imported CSV points to the /{nameof(context.StartTime)} value"},
                 new Option {Key = nameof(context.CsvRemoveDuplicatePoints), Setter = value => context.CsvRemoveDuplicatePoints = bool.Parse(value), Getter = () => context.CsvRemoveDuplicatePoints.ToString(), Description = "Remove duplicate points in the CSV before appending."},
-                new Option {Key = nameof(context.CsvDelimiter), Setter = value => context.CsvDelimiter = value, Getter = () => context.CsvDelimiter, Description = "Delimiter between CSV fields."},
+                new Option {Key = nameof(context.CsvDelimiter), Setter = value => context.CsvDelimiter = HttpUtility.UrlDecode(value), Getter = () => context.CsvDelimiter, Description = "Delimiter between CSV fields. (use %20 for space or %09 for tab)"},
                 new Option {Key = nameof(context.CsvNanValue), Setter = value => context.CsvNanValue = value, Getter = () => context.CsvNanValue, Description = "Special value text used to represent NaN values"},
                 new Option {Key = "CsvFormat", Description = "Shortcut for known CSV formats. One of 'NG', '3X', or 'PointZilla'. [default: NG]", Setter =
                     value =>

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/Readme.md
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/Readme.md
@@ -419,7 +419,7 @@ Supported -option=value settings (/option=value works too):
   -CsvIgnoreInvalidRows     Ignore CSV rows that can't be parsed [default: True]
   -CsvRealign               Realign imported CSV points to the /StartTime value [default: False]
   -CsvRemoveDuplicatePoints Remove duplicate points in the CSV before appending. [default: True]
-  -CsvDelimiter             Delimiter between CSV fields. [default: ,]
+  -CsvDelimiter             Delimiter between CSV fields. (use %20 for space or %09 for tab) [default: ,]
   -CsvNanValue              Special value text used to represent NaN values
   -CsvFormat                Shortcut for known CSV formats. One of 'NG', '3X', or 'PointZilla'. [default: NG]
   -ExcelSheetNumber         Excel worksheet number to parse [default to first sheet]


### PR DESCRIPTION
This allows `-CsvDelimiter=%20` for files delimited with a space and `-CsvDelimiter=%09` for files delimited with a tab