### PR TITLE
PF-1044 - Improved the format of raised HTTP errors

### DIFF
--- a/TimeSeries/PublicApis/Python/Readme.md
+++ b/TimeSeries/PublicApis/Python/Readme.md
@@ -14,7 +14,7 @@ $ pip install requests pytz pyrfc3339
 ```
 
 ## Revision History
-
+- 2021-Sep-04 - Improved format of web service error messages for AQTS and AQSamples
 - 2021-Sep-03 - `timeseries_client.datetime()` now handles with "24:00" timestamps correctly
 - 2021-Sep-01 - Fairly big internal refactoring, with minimal breaking external changes.
     - Dropped Python 2.x support


### PR DESCRIPTION
Expose more of the content from AQTS and AQSamples error responses.

This should help make the source of errors a bit more obvious to the clients.