### PR TITLE
PF-1365 - Minor tweaks

### DIFF
--- a/Samples/DotNetSdk/LabFileImporter/LabFileImporter.csproj
+++ b/Samples/DotNetSdk/LabFileImporter/LabFileImporter.csproj
@@ -60,8 +60,8 @@
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=106.11.7.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.106.11.7\lib\net452\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=106.15.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.15.0\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
       <HintPath>..\packages\ServiceStack.Client.5.10.4\lib\net45\ServiceStack.Client.dll</HintPath>
@@ -73,7 +73,7 @@
       <HintPath>..\packages\ServiceStack.Interfaces.5.10.4\lib\net472\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Logging.Log4Net, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Logging.Log4Net.5.9.0\lib\net45\ServiceStack.Logging.Log4Net.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Logging.Log4Net.5.10.4\lib\net45\ServiceStack.Logging.Log4Net.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
       <HintPath>..\packages\ServiceStack.Text.5.10.4\lib\net45\ServiceStack.Text.dll</HintPath>

--- a/Samples/DotNetSdk/LabFileImporter/packages.config
+++ b/Samples/DotNetSdk/LabFileImporter/packages.config
@@ -13,11 +13,11 @@
   <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net472" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net472" />
   <package id="NodaTime" version="1.3.0" targetFramework="net472" />
-  <package id="RestSharp" version="106.12.0" targetFramework="net472" />
+  <package id="RestSharp" version="106.15.0" targetFramework="net472" />
   <package id="ServiceStack.Client" version="5.10.4" targetFramework="net472" />
   <package id="ServiceStack.HttpClient" version="5.10.4" targetFramework="net472" />
   <package id="ServiceStack.Interfaces" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Logging.Log4Net" version="5.9.0" targetFramework="net472" />
+  <package id="ServiceStack.Logging.Log4Net" version="5.10.4" targetFramework="net472" />
   <package id="ServiceStack.Text" version="5.10.4" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Memory" version="4.5.4" targetFramework="net472" />

--- a/Samples/DotNetSdk/NWFWMD-LabFileImporter/NWFWMD-LabFileImporter.csproj
+++ b/Samples/DotNetSdk/NWFWMD-LabFileImporter/NWFWMD-LabFileImporter.csproj
@@ -58,8 +58,8 @@
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=106.11.7.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.106.11.7\lib\net452\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=106.15.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.15.0\lib\net452\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
       <HintPath>..\packages\ServiceStack.Client.5.10.4\lib\net45\ServiceStack.Client.dll</HintPath>
@@ -71,7 +71,7 @@
       <HintPath>..\packages\ServiceStack.Interfaces.5.10.4\lib\net472\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Logging.Log4Net, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Logging.Log4Net.5.9.0\lib\net45\ServiceStack.Logging.Log4Net.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Logging.Log4Net.5.10.4\lib\net45\ServiceStack.Logging.Log4Net.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
       <HintPath>..\packages\ServiceStack.Text.5.10.4\lib\net45\ServiceStack.Text.dll</HintPath>

--- a/Samples/DotNetSdk/NWFWMD-LabFileImporter/packages.config
+++ b/Samples/DotNetSdk/NWFWMD-LabFileImporter/packages.config
@@ -12,11 +12,11 @@
   <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net472" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net472" />
   <package id="NodaTime" version="1.3.0" targetFramework="net472" />
-  <package id="RestSharp" version="106.12.0" targetFramework="net472" />
+  <package id="RestSharp" version="106.15.0" targetFramework="net472" />
   <package id="ServiceStack.Client" version="5.10.4" targetFramework="net472" />
   <package id="ServiceStack.HttpClient" version="5.10.4" targetFramework="net472" />
   <package id="ServiceStack.Interfaces" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Logging.Log4Net" version="5.9.0" targetFramework="net472" />
+  <package id="ServiceStack.Logging.Log4Net" version="5.10.4" targetFramework="net472" />
   <package id="ServiceStack.Text" version="5.10.4" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Memory" version="4.5.4" targetFramework="net472" />

--- a/Samples/DotNetSdk/ObservationReportExporter/ObservationReportExporter.csproj
+++ b/Samples/DotNetSdk/ObservationReportExporter/ObservationReportExporter.csproj
@@ -248,6 +248,7 @@
     <Compile Include="Option.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SingleInstanceGuard.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/Samples/DotNetSdk/ObservationReportExporter/ObservationReportExporter.csproj
+++ b/Samples/DotNetSdk/ObservationReportExporter/ObservationReportExporter.csproj
@@ -144,8 +144,8 @@
       <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
-    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Net.Http.4.3.0\lib\net46\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
@@ -215,7 +215,7 @@
     </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Text.RegularExpressions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.RegularExpressions.4.3.0\lib\net463\System.Text.RegularExpressions.dll</HintPath>
+      <HintPath>..\packages\System.Text.RegularExpressions.4.3.1\lib\net463\System.Text.RegularExpressions.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>

--- a/Samples/DotNetSdk/ObservationReportExporter/SingleInstanceGuard.cs
+++ b/Samples/DotNetSdk/ObservationReportExporter/SingleInstanceGuard.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Reflection;
+using System.Threading;
+using log4net;
+
+namespace ObservationReportExporter
+{
+    public class SingleInstanceGuard : IDisposable
+    {
+        // ReSharper disable once PossibleNullReferenceException
+        private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        private Mutex InstanceMutex { get; set; }
+        public string Name { get; }
+        private bool ShouldRelease { get; set; }
+
+        public SingleInstanceGuard(string name)
+        {
+            Name = $"{ExeHelper.ExeName}.{name}";
+            InstanceMutex = new Mutex(true, Name);
+            ShouldRelease = true;
+        }
+
+        public bool IsAnotherInstanceRunning()
+        {
+            try
+            {
+                var isAnotherInstanceRunning = !InstanceMutex.WaitOne(TimeSpan.Zero, true);
+
+                if (isAnotherInstanceRunning)
+                {
+                    ShouldRelease = false;
+                }
+
+                return isAnotherInstanceRunning;
+            }
+            catch (AbandonedMutexException)
+            {
+                Log.Debug($"Previous run of the program did not clear the '{Name}' mutex cleanly.");
+
+                return false;
+            }
+            catch (Exception ex)
+            {
+                Log.Warn($"Error occurred while checking if the program is still running:'{ex.Message}'. Will continue.");
+            }
+
+            return false;
+        }
+
+        public void Dispose()
+        {
+            Release();
+
+            InstanceMutex?.Dispose();
+        }
+
+        private void Release()
+        {
+            if (!ShouldRelease)
+                return;
+
+            try
+            {
+                InstanceMutex?.ReleaseMutex();
+            }
+            catch (Exception e)
+            {
+                Log.Warn($"Can't release mutex '{Name}': {e.Message}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
1) Ensure only one instance-per-config runs per computer.

This allows you to schedule a configuration on a 3-hour schedule which sometimes takes 4 hours to complete, and avoid kicking off another cycle before the first one is actually done.

2) Log the number of exported observations per location

3) Documented the basic workflow and scheduling options