### PR TITLE
AT-669 Address NuGet Packages Vulnerabilities

### DIFF
--- a/Samples/CSharpExamples/ImportObservationFile/ImportObservationFile.csproj
+++ b/Samples/CSharpExamples/ImportObservationFile/ImportObservationFile.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RestSharp" Version="111.4.1" />
+    <PackageReference Include="RestSharp" Version="112.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Samples/DotNetSdk/LabFileImporter/LabFileImporter.csproj
+++ b/Samples/DotNetSdk/LabFileImporter/LabFileImporter.csproj
@@ -36,8 +36,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Aquarius.Client, Version=20.4.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aquarius.SDK.20.4.5\lib\net472\Aquarius.Client.dll</HintPath>
+    <Reference Include="Aquarius.Client, Version=24.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.SDK.24.2.0\lib\net472\Aquarius.Client.dll</HintPath>
     </Reference>
     <Reference Include="Costura, Version=4.1.0.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
       <HintPath>..\packages\Costura.Fody.4.1.0\lib\net40\Costura.dll</HintPath>
@@ -54,29 +54,30 @@
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="RestSharp, Version=106.15.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.15.0\lib\net452\RestSharp.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.5.10.4\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.6.0.2\lib\net472\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.HttpClient, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.HttpClient.5.10.4\lib\net45\ServiceStack.HttpClient.dll</HintPath>
+    <Reference Include="ServiceStack.HttpClient, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.HttpClient.6.0.2\lib\net472\ServiceStack.HttpClient.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.5.10.4\lib\net472\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.6.0.2\lib\net472\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Logging.Log4Net, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Logging.Log4Net.5.10.4\lib\net45\ServiceStack.Logging.Log4Net.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Logging.Log4Net.6.0.2\lib\net472\ServiceStack.Logging.Log4Net.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.5.10.4\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.6.0.2\lib\net472\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Samples/DotNetSdk/LabFileImporter/packages.config
+++ b/Samples/DotNetSdk/LabFileImporter/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.SDK" version="21.1.0" targetFramework="net472" />
+  <package id="Aquarius.SDK" version="24.2.0" targetFramework="net472" />
   <package id="Costura.Fody" version="4.1.0" targetFramework="net472" />
   <package id="ExcelDataReader" version="3.6.0" targetFramework="net472" />
   <package id="ExcelDataReader.DataSet" version="3.6.0" targetFramework="net472" />
@@ -8,17 +8,17 @@
   <package id="Humanizer.Core" version="2.8.26" targetFramework="net472" />
   <package id="log4net" version="2.0.12" targetFramework="net472" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net472" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net472" />
-  <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net472" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net472" />
   <package id="NodaTime" version="1.3.0" targetFramework="net472" />
   <package id="RestSharp" version="106.15.0" targetFramework="net472" />
-  <package id="ServiceStack.Client" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.HttpClient" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Interfaces" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Logging.Log4Net" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Text" version="5.10.4" targetFramework="net472" />
+  <package id="ServiceStack.Client" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.HttpClient" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Interfaces" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Logging.Log4Net" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Text" version="6.0.2" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Memory" version="4.5.4" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />

--- a/Samples/DotNetSdk/NWFWMD-LabFileImporter/NWFWMD-LabFileImporter.csproj
+++ b/Samples/DotNetSdk/NWFWMD-LabFileImporter/NWFWMD-LabFileImporter.csproj
@@ -36,8 +36,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Aquarius.Client, Version=20.4.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aquarius.SDK.20.4.5\lib\net472\Aquarius.Client.dll</HintPath>
+    <Reference Include="Aquarius.Client, Version=24.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.SDK.24.2.0\lib\net472\Aquarius.Client.dll</HintPath>
     </Reference>
     <Reference Include="Costura, Version=4.1.0.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
       <HintPath>..\packages\Costura.Fody.4.1.0\lib\net40\Costura.dll</HintPath>
@@ -51,30 +51,31 @@
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualBasic" />
+    <Reference Include="mscorlib" />
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="RestSharp, Version=106.15.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.15.0\lib\net452\RestSharp.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.5.10.4\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.6.0.2\lib\net472\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.HttpClient, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.HttpClient.5.10.4\lib\net45\ServiceStack.HttpClient.dll</HintPath>
+    <Reference Include="ServiceStack.HttpClient, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.HttpClient.6.0.2\lib\net472\ServiceStack.HttpClient.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.5.10.4\lib\net472\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.6.0.2\lib\net472\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Logging.Log4Net, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Logging.Log4Net.5.10.4\lib\net45\ServiceStack.Logging.Log4Net.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Logging.Log4Net.6.0.2\lib\net472\ServiceStack.Logging.Log4Net.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.5.10.4\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.6.0.2\lib\net472\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Samples/DotNetSdk/NWFWMD-LabFileImporter/packages.config
+++ b/Samples/DotNetSdk/NWFWMD-LabFileImporter/packages.config
@@ -1,23 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.SDK" version="21.1.0" targetFramework="net472" />
+  <package id="Aquarius.SDK" version="24.2.0" targetFramework="net472" />
   <package id="Costura.Fody" version="4.1.0" targetFramework="net472" />
   <package id="Fastenshtein" version="1.0.0.7" targetFramework="net472" />
   <package id="Fody" version="6.0.0" targetFramework="net472" developmentDependency="true" />
   <package id="Humanizer.Core" version="2.8.26" targetFramework="net472" />
   <package id="log4net" version="2.0.12" targetFramework="net472" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net472" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net472" />
-  <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net472" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net472" />
   <package id="NodaTime" version="1.3.0" targetFramework="net472" />
   <package id="RestSharp" version="106.15.0" targetFramework="net472" />
-  <package id="ServiceStack.Client" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.HttpClient" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Interfaces" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Logging.Log4Net" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Text" version="5.10.4" targetFramework="net472" />
+  <package id="ServiceStack.Client" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.HttpClient" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Interfaces" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Logging.Log4Net" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Text" version="6.0.2" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Memory" version="4.5.4" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />

--- a/Samples/DotNetSdk/ObservationReportExporter/ObservationReportExporter.csproj
+++ b/Samples/DotNetSdk/ObservationReportExporter/ObservationReportExporter.csproj
@@ -36,8 +36,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Aquarius.Client, Version=21.4.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aquarius.SDK.21.4.2\lib\net472\Aquarius.Client.dll</HintPath>
+    <Reference Include="Aquarius.Client, Version=24.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.SDK.24.2.0\lib\net472\Aquarius.Client.dll</HintPath>
     </Reference>
     <Reference Include="Costura, Version=5.7.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Costura.Fody.5.7.0\lib\netstandard1.0\Costura.dll</HintPath>
@@ -48,31 +48,32 @@
     <Reference Include="log4net, Version=2.0.14.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.14\lib\net45\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.5.10.4\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.6.0.2\lib\net472\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.HttpClient, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.HttpClient.5.10.4\lib\net45\ServiceStack.HttpClient.dll</HintPath>
+    <Reference Include="ServiceStack.HttpClient, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.HttpClient.6.0.2\lib\net472\ServiceStack.HttpClient.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.5.10.4\lib\net472\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.6.0.2\lib\net472\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Logging.Log4Net, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Logging.Log4Net.5.10.4\lib\net45\ServiceStack.Logging.Log4Net.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Logging.Log4Net.6.0.2\lib\net472\ServiceStack.Logging.Log4Net.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.5.10.4\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.6.0.2\lib\net472\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.AppContext, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Samples/DotNetSdk/ObservationReportExporter/packages.config
+++ b/Samples/DotNetSdk/ObservationReportExporter/packages.config
@@ -1,24 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.SDK" version="21.4.2" targetFramework="net472" />
+  <package id="Aquarius.SDK" version="24.2.0" targetFramework="net472" />
   <package id="Costura.Fody" version="5.7.0" targetFramework="net472" developmentDependency="true" />
   <package id="Fody" version="6.5.5" targetFramework="net472" developmentDependency="true" />
   <package id="Humanizer.Core" version="2.14.1" targetFramework="net472" />
   <package id="log4net" version="2.0.14" targetFramework="net472" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net472" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net472" />
-  <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net472" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net472" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net472" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net472" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net472" />
   <package id="NodaTime" version="1.3.0" targetFramework="net472" />
-  <package id="ServiceStack.Client" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.HttpClient" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Interfaces" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Logging.Log4Net" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Text" version="5.10.4" targetFramework="net472" />
+  <package id="ServiceStack.Client" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.HttpClient" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Interfaces" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Logging.Log4Net" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Text" version="6.0.2" targetFramework="net472" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Collections" version="4.3.0" targetFramework="net472" />

--- a/Samples/DotNetSdk/ObservationValidator/App.config
+++ b/Samples/DotNetSdk/ObservationValidator/App.config
@@ -41,6 +41,10 @@
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Samples/DotNetSdk/ObservationValidator/ObservationValidator.csproj
+++ b/Samples/DotNetSdk/ObservationValidator/ObservationValidator.csproj
@@ -34,16 +34,17 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Aquarius.Client, Version=20.4.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aquarius.SDK.20.4.5\lib\net472\Aquarius.Client.dll</HintPath>
+    <Reference Include="Aquarius.Client, Version=21.1.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.SDK.21.1.1\lib\net472\Aquarius.Client.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="mscorlib" />
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>

--- a/Samples/DotNetSdk/ObservationValidator/ObservationValidator.csproj
+++ b/Samples/DotNetSdk/ObservationValidator/ObservationValidator.csproj
@@ -34,8 +34,8 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Aquarius.Client, Version=21.1.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aquarius.SDK.21.1.1\lib\net472\Aquarius.Client.dll</HintPath>
+    <Reference Include="Aquarius.Client, Version=24.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.SDK.24.2.0\lib\net472\Aquarius.Client.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
@@ -48,17 +48,17 @@
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.5.10.4\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.6.0.2\lib\net472\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.HttpClient, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.HttpClient.5.10.4\lib\net45\ServiceStack.HttpClient.dll</HintPath>
+    <Reference Include="ServiceStack.HttpClient, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.HttpClient.6.0.2\lib\net472\ServiceStack.HttpClient.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.5.10.4\lib\net472\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.6.0.2\lib\net472\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.5.10.4\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.6.0.2\lib\net472\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Samples/DotNetSdk/ObservationValidator/Program.cs
+++ b/Samples/DotNetSdk/ObservationValidator/Program.cs
@@ -73,7 +73,7 @@ namespace ObservationValidator
                     result.ProcessedSpecimenCount++;
 
 
-                    var observationResponse = client.Get(new GetObservations
+                    var observationResponse = client.Get(new GetObservationsV2
                     {
                         SpecimenName = specimen.Name, 
                         QualityControlTypes = new List<string> { "NORMAL"},
@@ -119,7 +119,7 @@ namespace ObservationValidator
                 if (invalidObservation.LabResultDetails?.QualityFlag == flag)
                     continue;
 
-                client.Put(new PutObservation
+                client.Put(new PutObservationV2
                 {
                     Id = invalidObservation.Id,
                     LabResultDetails = new LabResultDetails

--- a/Samples/DotNetSdk/ObservationValidator/packages.config
+++ b/Samples/DotNetSdk/ObservationValidator/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.SDK" version="20.4.5" targetFramework="net472" />
+  <package id="Aquarius.SDK" version="21.1.1" targetFramework="net472" />
   <package id="log4net" version="2.0.12" targetFramework="net47" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net47" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net47" />
-  <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net472" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net47" />
   <package id="NodaTime" version="1.3.0" targetFramework="net47" />
   <package id="ServiceStack.Client" version="5.10.4" targetFramework="net472" />

--- a/Samples/DotNetSdk/ObservationValidator/packages.config
+++ b/Samples/DotNetSdk/ObservationValidator/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.SDK" version="21.1.1" targetFramework="net472" />
+  <package id="Aquarius.SDK" version="24.2.0" targetFramework="net472" />
   <package id="log4net" version="2.0.12" targetFramework="net47" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net47" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
@@ -8,10 +8,10 @@
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net47" />
   <package id="NodaTime" version="1.3.0" targetFramework="net47" />
-  <package id="ServiceStack.Client" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.HttpClient" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Interfaces" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Text" version="5.10.4" targetFramework="net472" />
+  <package id="ServiceStack.Client" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.HttpClient" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Interfaces" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Text" version="6.0.2" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Memory" version="4.5.4" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />

--- a/Samples/DotNetSdk/SamplesObservationExporter/Exporter.cs
+++ b/Samples/DotNetSdk/SamplesObservationExporter/Exporter.cs
@@ -200,7 +200,7 @@ namespace SamplesObservationExporter
                     if (!first.FieldVisit?.StartTime.HasValue ?? true)
                         throw new ExpectedException($"{"observation".ToQuantity(observations.Count)} at location '{location.CustomId}' have no timestamp.");
 
-                    var time = first.FieldVisit.StartTime.Value.ToDateTimeOffset().Add(utcOffset);
+                    var time = first.FieldVisit.StartTime.Value.Add(utcOffset);
 
                     var columns = new List<string>(headerRow.Length)
                     {

--- a/Samples/DotNetSdk/SamplesObservationExporter/SamplesObservationExporter.csproj
+++ b/Samples/DotNetSdk/SamplesObservationExporter/SamplesObservationExporter.csproj
@@ -36,8 +36,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Aquarius.Client, Version=21.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aquarius.SDK.21.2.0\lib\net472\Aquarius.Client.dll</HintPath>
+    <Reference Include="Aquarius.Client, Version=24.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.SDK.24.2.0\lib\net472\Aquarius.Client.dll</HintPath>
     </Reference>
     <Reference Include="ConsoleProgressBar, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\ConsoleProgressBar.1.0.1\lib\net45\ConsoleProgressBar.dll</HintPath>
@@ -51,29 +51,30 @@
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="MoreLinq, Version=3.3.2.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
       <HintPath>..\packages\morelinq.3.3.2\lib\net451\MoreLinq.dll</HintPath>
     </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.5.10.4\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.6.0.2\lib\net472\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.HttpClient, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.HttpClient.5.10.4\lib\net45\ServiceStack.HttpClient.dll</HintPath>
+    <Reference Include="ServiceStack.HttpClient, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.HttpClient.6.0.2\lib\net472\ServiceStack.HttpClient.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.5.10.4\lib\net472\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.6.0.2\lib\net472\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Logging.Log4Net, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Logging.Log4Net.5.9.0\lib\net45\ServiceStack.Logging.Log4Net.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Logging.Log4Net.6.0.2\lib\net472\ServiceStack.Logging.Log4Net.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.5.10.4\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.6.0.2\lib\net472\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Samples/DotNetSdk/SamplesObservationExporter/SamplesObservationExporter.csproj
+++ b/Samples/DotNetSdk/SamplesObservationExporter/SamplesObservationExporter.csproj
@@ -36,8 +36,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Aquarius.Client, Version=20.4.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aquarius.SDK.20.4.5\lib\net472\Aquarius.Client.dll</HintPath>
+    <Reference Include="Aquarius.Client, Version=21.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.SDK.21.2.0\lib\net472\Aquarius.Client.dll</HintPath>
     </Reference>
     <Reference Include="ConsoleProgressBar, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\ConsoleProgressBar.1.0.1\lib\net45\ConsoleProgressBar.dll</HintPath>

--- a/Samples/DotNetSdk/SamplesObservationExporter/packages.config
+++ b/Samples/DotNetSdk/SamplesObservationExporter/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.SDK" version="20.4.5" targetFramework="net472" />
+  <package id="Aquarius.SDK" version="21.2.0" targetFramework="net472" />
   <package id="ConsoleProgressBar" version="1.0.1" targetFramework="net472" />
   <package id="Costura.Fody" version="4.1.0" targetFramework="net472" />
   <package id="Fody" version="6.0.0" targetFramework="net472" developmentDependency="true" />

--- a/Samples/DotNetSdk/SamplesObservationExporter/packages.config
+++ b/Samples/DotNetSdk/SamplesObservationExporter/packages.config
@@ -1,23 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.SDK" version="21.2.0" targetFramework="net472" />
+  <package id="Aquarius.SDK" version="24.2.0" targetFramework="net472" />
   <package id="ConsoleProgressBar" version="1.0.1" targetFramework="net472" />
   <package id="Costura.Fody" version="4.1.0" targetFramework="net472" />
   <package id="Fody" version="6.0.0" targetFramework="net472" developmentDependency="true" />
   <package id="Humanizer.Core" version="2.8.26" targetFramework="net472" />
   <package id="log4net" version="2.0.12" targetFramework="net472" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net472" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net472" />
-  <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net472" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net472" />
   <package id="morelinq" version="3.3.2" targetFramework="net472" />
   <package id="NodaTime" version="1.3.0" targetFramework="net472" />
-  <package id="ServiceStack.Client" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.HttpClient" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Interfaces" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Logging.Log4Net" version="5.9.0" targetFramework="net472" />
-  <package id="ServiceStack.Text" version="5.10.4" targetFramework="net472" />
+  <package id="ServiceStack.Client" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.HttpClient" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Interfaces" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Logging.Log4Net" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Text" version="6.0.2" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Memory" version="4.5.4" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />

--- a/Samples/DotNetSdk/SamplesPlannedSpecimenInstantiator/MainForm.cs
+++ b/Samples/DotNetSdk/SamplesPlannedSpecimenInstantiator/MainForm.cs
@@ -260,7 +260,7 @@ namespace SamplesTripScheduler
                 .Select(v => new TableItem
                 {
                     Trip = v.FieldTrip.CustomId,
-                    Start = v.StartTime.Value.ToDateTimeUtc().Add(DateTimeOffset.Now.Offset),
+                    Start = v.StartTime.Value.UtcDateTime.Add(DateTimeOffset.Now.Offset),
                     Location = v.SamplingLocation.CustomId,
                     Specimens = $"{v.PlannedActivities.SelectMany(a => a.ActivityTemplate.SpecimenTemplates).Count()} specimens",
                     Visit = v

--- a/Samples/DotNetSdk/SamplesPlannedSpecimenInstantiator/SamplesPlannedSpecimenInstantiator.csproj
+++ b/Samples/DotNetSdk/SamplesPlannedSpecimenInstantiator/SamplesPlannedSpecimenInstantiator.csproj
@@ -35,8 +35,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Aquarius.Client, Version=21.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aquarius.SDK.21.2.0\lib\net472\Aquarius.Client.dll</HintPath>
+    <Reference Include="Aquarius.Client, Version=24.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.SDK.24.2.0\lib\net472\Aquarius.Client.dll</HintPath>
     </Reference>
     <Reference Include="Costura, Version=1.6.2.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
       <HintPath>..\packages\Costura.Fody.1.6.2\lib\dotnet\Costura.dll</HintPath>
@@ -48,23 +48,24 @@
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.5.10.4\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.6.0.2\lib\net472\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.HttpClient, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.HttpClient.5.10.4\lib\net45\ServiceStack.HttpClient.dll</HintPath>
+    <Reference Include="ServiceStack.HttpClient, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.HttpClient.6.0.2\lib\net472\ServiceStack.HttpClient.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.5.10.4\lib\net472\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.6.0.2\lib\net472\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.5.10.4\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.6.0.2\lib\net472\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Samples/DotNetSdk/SamplesPlannedSpecimenInstantiator/SamplesPlannedSpecimenInstantiator.csproj
+++ b/Samples/DotNetSdk/SamplesPlannedSpecimenInstantiator/SamplesPlannedSpecimenInstantiator.csproj
@@ -35,8 +35,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Aquarius.Client, Version=20.4.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aquarius.SDK.20.4.5\lib\net472\Aquarius.Client.dll</HintPath>
+    <Reference Include="Aquarius.Client, Version=21.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.SDK.21.2.0\lib\net472\Aquarius.Client.dll</HintPath>
     </Reference>
     <Reference Include="Costura, Version=1.6.2.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
       <HintPath>..\packages\Costura.Fody.1.6.2\lib\dotnet\Costura.dll</HintPath>

--- a/Samples/DotNetSdk/SamplesPlannedSpecimenInstantiator/packages.config
+++ b/Samples/DotNetSdk/SamplesPlannedSpecimenInstantiator/packages.config
@@ -1,20 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.SDK" version="21.2.0" targetFramework="net472" />
+  <package id="Aquarius.SDK" version="24.2.0" targetFramework="net472" />
   <package id="Costura.Fody" version="1.6.2" targetFramework="net472" developmentDependency="true" />
   <package id="Fody" version="2.0.0" targetFramework="net472" developmentDependency="true" />
   <package id="Humanizer.Core" version="2.7.9" targetFramework="net472" />
   <package id="log4net" version="2.0.12" targetFramework="net472" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net472" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net472" />
-  <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net472" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net472" />
   <package id="NodaTime" version="1.3.0" targetFramework="net472" />
-  <package id="ServiceStack.Client" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.HttpClient" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Interfaces" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Text" version="5.10.4" targetFramework="net472" />
+  <package id="ServiceStack.Client" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.HttpClient" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Interfaces" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Text" version="6.0.2" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Memory" version="4.5.4" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />

--- a/Samples/DotNetSdk/SamplesPlannedSpecimenInstantiator/packages.config
+++ b/Samples/DotNetSdk/SamplesPlannedSpecimenInstantiator/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.SDK" version="20.4.5" targetFramework="net472" />
+  <package id="Aquarius.SDK" version="21.2.0" targetFramework="net472" />
   <package id="Costura.Fody" version="1.6.2" targetFramework="net472" developmentDependency="true" />
   <package id="Fody" version="2.0.0" targetFramework="net472" developmentDependency="true" />
   <package id="Humanizer.Core" version="2.7.9" targetFramework="net472" />

--- a/Samples/DotNetSdk/SondeFileImporter/SondeFileImporter.csproj
+++ b/Samples/DotNetSdk/SondeFileImporter/SondeFileImporter.csproj
@@ -52,8 +52,8 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Aquarius.Client, Version=20.4.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aquarius.SDK.20.4.5\lib\net472\Aquarius.Client.dll</HintPath>
+    <Reference Include="Aquarius.Client, Version=24.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.SDK.24.2.0\lib\net472\Aquarius.Client.dll</HintPath>
     </Reference>
     <Reference Include="ExcelDataReader, Version=3.6.0.0, Culture=neutral, PublicKeyToken=93517dbe6a4012fa, processorArchitecture=MSIL">
       <HintPath>..\packages\ExcelDataReader.3.6.0\lib\net45\ExcelDataReader.dll</HintPath>
@@ -64,23 +64,24 @@
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.5.10.4\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.6.0.2\lib\net472\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.HttpClient, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.HttpClient.5.10.4\lib\net45\ServiceStack.HttpClient.dll</HintPath>
+    <Reference Include="ServiceStack.HttpClient, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.HttpClient.6.0.2\lib\net472\ServiceStack.HttpClient.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.5.10.4\lib\net472\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.6.0.2\lib\net472\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.5.10.4\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.6.0.2\lib\net472\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Samples/DotNetSdk/SondeFileImporter/packages.config
+++ b/Samples/DotNetSdk/SondeFileImporter/packages.config
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.SDK" version="20.4.5" targetFramework="net472" />
+  <package id="Aquarius.SDK" version="24.2.0" targetFramework="net472" />
   <package id="ExcelDataReader" version="3.6.0" targetFramework="net472" />
   <package id="ExcelDataReader.DataSet" version="3.6.0" targetFramework="net472" />
   <package id="log4net" version="2.0.12" targetFramework="net472" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net472" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net472" />
-  <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net472" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net472" />
   <package id="NodaTime" version="1.3.0" targetFramework="net472" />
-  <package id="ServiceStack.Client" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.HttpClient" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Interfaces" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Text" version="5.10.4" targetFramework="net472" />
+  <package id="ServiceStack.Client" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.HttpClient" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Interfaces" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Text" version="6.0.2" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Memory" version="4.5.4" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />

--- a/TimeSeries/PublicApis/SdkExamples/AppendPoints/AppendPoints.csproj
+++ b/TimeSeries/PublicApis/SdkExamples/AppendPoints/AppendPoints.csproj
@@ -34,28 +34,39 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Aquarius.Client, Version=19.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aquarius.SDK.19.4.0\lib\net45\Aquarius.Client.dll</HintPath>
+    <Reference Include="Aquarius.Client, Version=24.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.SDK.24.2.0\lib\net472\Aquarius.Client.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=4.5.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.4.5.12\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.6.0.2\lib\net472\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.HttpClient, Version=4.5.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.HttpClient.4.5.12\lib\net45\ServiceStack.HttpClient.dll</HintPath>
+    <Reference Include="ServiceStack.HttpClient, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.HttpClient.6.0.2\lib\net472\ServiceStack.HttpClient.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.4.5.12\lib\portable-wp80+sl5+net45+win8+wpa81+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.6.0.2\lib\net472\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=4.5.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.4.5.12\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.6.0.2\lib\net472\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
       <Private>True</Private>
@@ -65,6 +76,20 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/TimeSeries/PublicApis/SdkExamples/AppendPoints/packages.config
+++ b/TimeSeries/PublicApis/SdkExamples/AppendPoints/packages.config
@@ -1,12 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.SDK" version="19.4.0" targetFramework="net462" />
+  <package id="Aquarius.SDK" version="24.2.0" targetFramework="net472" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net462" />
+  <package id="ServiceStack.Client" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.HttpClient" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Interfaces" version="6.0.2" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net462" />
+  <package id="ServiceStack.Text" version="6.0.2" targetFramework="net472" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net462" />
   <package id="NodaTime" version="1.3.0" targetFramework="net462" />
-  <package id="ServiceStack.Client" version="4.5.12" targetFramework="net462" />
-  <package id="ServiceStack.HttpClient" version="4.5.12" targetFramework="net462" />
-  <package id="ServiceStack.Interfaces" version="4.5.12" targetFramework="net462" />
-  <package id="ServiceStack.Text" version="4.5.12" targetFramework="net462" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/TimeSeries/PublicApis/SdkExamples/ChangeVisitApprovals/ChangeVisitApprovals.csproj
+++ b/TimeSeries/PublicApis/SdkExamples/ChangeVisitApprovals/ChangeVisitApprovals.csproj
@@ -37,8 +37,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Aquarius.Client, Version=20.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aquarius.SDK.20.1.2\lib\net45\Aquarius.Client.dll</HintPath>
+    <Reference Include="Aquarius.Client, Version=24.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.SDK.24.2.0\lib\net472\Aquarius.Client.dll</HintPath>
     </Reference>
     <Reference Include="Costura, Version=1.6.2.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
       <HintPath>..\packages\Costura.Fody.1.6.2\lib\dotnet\Costura.dll</HintPath>
@@ -50,34 +50,39 @@
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="mscorlib" />
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.5.8.0\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.6.0.2\lib\net472\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.HttpClient, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.HttpClient.5.8.0\lib\net45\ServiceStack.HttpClient.dll</HintPath>
+    <Reference Include="ServiceStack.HttpClient, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.HttpClient.6.0.2\lib\net472\ServiceStack.HttpClient.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.5.8.0\lib\net45\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.6.0.2\lib\net472\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Logging.Log4Net, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Logging.Log4Net.5.8.0\lib\net45\ServiceStack.Logging.Log4Net.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Logging.Log4Net.6.0.2\lib\net472\ServiceStack.Logging.Log4Net.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.5.8.0\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.6.0.2\lib\net472\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.4.5.3\lib\netstandard2.0\System.Memory.dll</HintPath>
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
@@ -86,14 +91,17 @@
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>

--- a/TimeSeries/PublicApis/SdkExamples/ChangeVisitApprovals/packages.config
+++ b/TimeSeries/PublicApis/SdkExamples/ChangeVisitApprovals/packages.config
@@ -1,23 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.SDK" version="20.1.2" targetFramework="net472" />
+  <package id="Aquarius.SDK" version="24.2.0" targetFramework="net472" />
   <package id="Costura.Fody" version="1.6.2" targetFramework="net47" developmentDependency="true" />
   <package id="Fody" version="2.0.0" targetFramework="net47" developmentDependency="true" />
   <package id="Humanizer.Core" version="2.2.0" targetFramework="net47" />
+  <package id="ServiceStack.Client" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.HttpClient" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Interfaces" version="6.0.2" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="log4net" version="2.0.12" targetFramework="net472" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net47" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net47" />
-  <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net472" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net47" />
   <package id="NodaTime" version="1.3.0" targetFramework="net47" />
-  <package id="ServiceStack.Client" version="5.8.0" targetFramework="net472" />
-  <package id="ServiceStack.HttpClient" version="5.8.0" targetFramework="net472" />
-  <package id="ServiceStack.Interfaces" version="5.8.0" targetFramework="net472" />
-  <package id="ServiceStack.Logging.Log4Net" version="5.8.0" targetFramework="net472" />
-  <package id="ServiceStack.Text" version="5.8.0" targetFramework="net472" />
-  <package id="System.Buffers" version="4.4.0" targetFramework="net472" />
-  <package id="System.Memory" version="4.5.3" targetFramework="net472" />
-  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net472" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net472" />
+  <package id="ServiceStack.Logging.Log4Net" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Text" version="6.0.2" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/TimeSeries/PublicApis/SdkExamples/ExternalProcessor/ExternalProcessor.csproj
+++ b/TimeSeries/PublicApis/SdkExamples/ExternalProcessor/ExternalProcessor.csproj
@@ -34,28 +34,39 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Aquarius.Client, Version=19.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aquarius.SDK.19.4.0\lib\net45\Aquarius.Client.dll</HintPath>
+    <Reference Include="Aquarius.Client, Version=24.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.SDK.24.2.0\lib\net472\Aquarius.Client.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=4.5.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.4.5.12\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.6.0.2\lib\net472\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.HttpClient, Version=4.5.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.HttpClient.4.5.12\lib\net45\ServiceStack.HttpClient.dll</HintPath>
+    <Reference Include="ServiceStack.HttpClient, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.HttpClient.6.0.2\lib\net472\ServiceStack.HttpClient.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.4.5.12\lib\portable-wp80+sl5+net45+win8+wpa81+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.6.0.2\lib\net472\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=4.5.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.4.5.12\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.6.0.2\lib\net472\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
       <Private>True</Private>
@@ -65,6 +76,20 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/TimeSeries/PublicApis/SdkExamples/ExternalProcessor/packages.config
+++ b/TimeSeries/PublicApis/SdkExamples/ExternalProcessor/packages.config
@@ -1,12 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.SDK" version="19.4.0" targetFramework="net472" />
+  <package id="Aquarius.SDK" version="24.2.0" targetFramework="net472" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net462" />
+  <package id="ServiceStack.Client" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.HttpClient" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Interfaces" version="6.0.2" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net462" />
+  <package id="ServiceStack.Text" version="6.0.2" targetFramework="net472" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net462" />
   <package id="NodaTime" version="1.3.0" targetFramework="net462" />
-  <package id="ServiceStack.Client" version="4.5.12" targetFramework="net462" />
-  <package id="ServiceStack.HttpClient" version="4.5.12" targetFramework="net462" />
-  <package id="ServiceStack.Interfaces" version="4.5.12" targetFramework="net462" />
-  <package id="ServiceStack.Text" version="4.5.12" targetFramework="net462" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/TimeSeries/PublicApis/SdkExamples/LocationDeleter/App.config
+++ b/TimeSeries/PublicApis/SdkExamples/LocationDeleter/App.config
@@ -9,6 +9,10 @@
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.12.0" newVersion="2.0.12.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="ServiceStack.Interfaces" publicKeyToken="02c12cbda47e6587" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/TimeSeries/PublicApis/SdkExamples/LocationDeleter/LocationDeleter.csproj
+++ b/TimeSeries/PublicApis/SdkExamples/LocationDeleter/LocationDeleter.csproj
@@ -43,8 +43,8 @@
     <Reference Include="AQSystemMLib">
       <HintPath>InternalLibraries\AQSystemMLib.dll</HintPath>
     </Reference>
-    <Reference Include="Aquarius.Client, Version=20.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aquarius.SDK.20.1.2\lib\net45\Aquarius.Client.dll</HintPath>
+    <Reference Include="Aquarius.Client, Version=24.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.SDK.24.2.0\lib\net472\Aquarius.Client.dll</HintPath>
     </Reference>
     <Reference Include="Aquarius.Client.Legacy, Version=20.1.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Aquarius.SDK.Legacy.20.1.2\lib\net45\Aquarius.Client.Legacy.dll</HintPath>
@@ -62,7 +62,11 @@
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="mscorlib" />
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>InternalLibraries\Newtonsoft.Json.dll</HintPath>
@@ -70,30 +74,31 @@
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.5.8.0\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.6.0.2\lib\net472\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.HttpClient, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.HttpClient.5.8.0\lib\net45\ServiceStack.HttpClient.dll</HintPath>
+    <Reference Include="ServiceStack.HttpClient, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.HttpClient.6.0.2\lib\net472\ServiceStack.HttpClient.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.5.8.0\lib\net45\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.6.0.2\lib\net472\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Logging.Log4Net, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Logging.Log4Net.5.8.0\lib\net45\ServiceStack.Logging.Log4Net.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Logging.Log4Net.6.0.2\lib\net472\ServiceStack.Logging.Log4Net.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.5.8.0\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.6.0.2\lib\net472\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.4.5.3\lib\netstandard2.0\System.Memory.dll</HintPath>
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
@@ -102,14 +107,17 @@
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>

--- a/TimeSeries/PublicApis/SdkExamples/LocationDeleter/packages.config
+++ b/TimeSeries/PublicApis/SdkExamples/LocationDeleter/packages.config
@@ -1,24 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.SDK" version="20.1.2" targetFramework="net472" />
+  <package id="Aquarius.SDK" version="24.2.0" targetFramework="net472" />
   <package id="Aquarius.SDK.Legacy" version="20.1.2" targetFramework="net472" />
   <package id="Costura.Fody" version="1.6.2" targetFramework="net47" developmentDependency="true" />
   <package id="Fody" version="2.0.0" targetFramework="net47" developmentDependency="true" />
   <package id="Humanizer.Core" version="2.2.0" targetFramework="net47" />
+  <package id="ServiceStack.Client" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.HttpClient" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Interfaces" version="6.0.2" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="log4net" version="2.0.12" targetFramework="net472" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net47" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net47" />
-  <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net472" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net47" />
   <package id="NodaTime" version="1.3.0" targetFramework="net47" />
-  <package id="ServiceStack.Client" version="5.8.0" targetFramework="net472" />
-  <package id="ServiceStack.HttpClient" version="5.8.0" targetFramework="net472" />
-  <package id="ServiceStack.Interfaces" version="5.8.0" targetFramework="net472" />
-  <package id="ServiceStack.Logging.Log4Net" version="5.8.0" targetFramework="net472" />
-  <package id="ServiceStack.Text" version="5.8.0" targetFramework="net472" />
-  <package id="System.Buffers" version="4.4.0" targetFramework="net472" />
-  <package id="System.Memory" version="4.5.3" targetFramework="net472" />
-  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net472" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net472" />
+  <package id="ServiceStack.Logging.Log4Net" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Text" version="6.0.2" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/App.config
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/App.config
@@ -19,7 +19,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -36,6 +36,18 @@
       <dependentAssembly>
         <assemblyIdentity name="NodaTime" publicKeyToken="4226afe0d9b296d1" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.4.0.0" newVersion="1.4.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Aquarius.Client" publicKeyToken="null" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-21.2.3.0" newVersion="21.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/App.config
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/App.config
@@ -14,10 +14,6 @@
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
@@ -30,16 +26,8 @@
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Google.Protobuf" publicKeyToken="a7d26565bac4d604" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.15.0.0" newVersion="3.15.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="NodaTime" publicKeyToken="4226afe0d9b296d1" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.4.0.0" newVersion="1.4.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Aquarius.Client" publicKeyToken="null" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-21.2.3.0" newVersion="21.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -48,6 +36,10 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="ServiceStack.Interfaces" publicKeyToken="02c12cbda47e6587" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/PointZilla.csproj
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/PointZilla.csproj
@@ -37,8 +37,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Aquarius.Client, Version=21.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aquarius.SDK.21.2.3\lib\net472\Aquarius.Client.dll</HintPath>
+    <Reference Include="Aquarius.Client, Version=24.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.SDK.24.2.0\lib\net472\Aquarius.Client.dll</HintPath>
     </Reference>
     <Reference Include="Aquarius.Client.Legacy, Version=20.1.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Aquarius.SDK.Legacy.20.1.2\lib\net45\Aquarius.Client.Legacy.dll</HintPath>
@@ -92,20 +92,20 @@
     <Reference Include="Npgsql, Version=4.0.14.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
       <HintPath>..\packages\Npgsql.4.0.14\lib\net451\Npgsql.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.5.10.4\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.6.0.2\lib\net472\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.HttpClient, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.HttpClient.5.10.4\lib\net45\ServiceStack.HttpClient.dll</HintPath>
+    <Reference Include="ServiceStack.HttpClient, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.HttpClient.6.0.2\lib\net472\ServiceStack.HttpClient.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.5.10.4\lib\net472\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.6.0.2\lib\net472\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Logging.Log4Net, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Logging.Log4Net.5.8.0\lib\net45\ServiceStack.Logging.Log4Net.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Logging.Log4Net.6.0.2\lib\net472\ServiceStack.Logging.Log4Net.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.5.10.4\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.6.0.2\lib\net472\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/PointZilla.csproj
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/PointZilla.csproj
@@ -43,8 +43,8 @@
     <Reference Include="Aquarius.Client.Legacy, Version=20.1.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Aquarius.SDK.Legacy.20.1.2\lib\net45\Aquarius.Client.Legacy.dll</HintPath>
     </Reference>
-    <Reference Include="BouncyCastle.Crypto, Version=1.8.5.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
-      <HintPath>..\packages\BouncyCastle.1.8.5\lib\BouncyCastle.Crypto.dll</HintPath>
+    <Reference Include="BouncyCastle.Cryptography, Version=2.0.0.0, Culture=neutral, PublicKeyToken=072edcf4a5328938, processorArchitecture=MSIL">
+      <HintPath>..\packages\BouncyCastle.Cryptography.2.3.1\lib\net461\BouncyCastle.Cryptography.dll</HintPath>
     </Reference>
     <Reference Include="Costura, Version=1.6.2.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
       <HintPath>..\packages\Costura.Fody.1.6.2\lib\dotnet\Costura.dll</HintPath>
@@ -59,37 +59,38 @@
     <Reference Include="Fastenshtein, Version=1.0.0.8, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Fastenshtein.1.0.0.8\lib\net452\Fastenshtein.dll</HintPath>
     </Reference>
-    <Reference Include="Google.Protobuf, Version=3.15.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Protobuf.3.15.0\lib\net45\Google.Protobuf.dll</HintPath>
+    <Reference Include="Google.Protobuf, Version=3.21.9.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Protobuf.3.21.9\lib\net45\Google.Protobuf.dll</HintPath>
     </Reference>
     <Reference Include="Humanizer, Version=2.8.0.0, Culture=neutral, PublicKeyToken=979442b78dfc278e, processorArchitecture=MSIL">
       <HintPath>..\packages\Humanizer.Core.2.8.26\lib\netstandard2.0\Humanizer.dll</HintPath>
     </Reference>
-    <Reference Include="K4os.Compression.LZ4, Version=1.1.11.0, Culture=neutral, PublicKeyToken=2186fa9121ef231d, processorArchitecture=MSIL">
-      <HintPath>..\packages\K4os.Compression.LZ4.1.1.11\lib\net46\K4os.Compression.LZ4.dll</HintPath>
+    <Reference Include="K4os.Compression.LZ4, Version=1.3.5.0, Culture=neutral, PublicKeyToken=2186fa9121ef231d, processorArchitecture=MSIL">
+      <HintPath>..\packages\K4os.Compression.LZ4.1.3.5\lib\net462\K4os.Compression.LZ4.dll</HintPath>
     </Reference>
-    <Reference Include="K4os.Compression.LZ4.Streams, Version=1.1.11.0, Culture=neutral, PublicKeyToken=2186fa9121ef231d, processorArchitecture=MSIL">
-      <HintPath>..\packages\K4os.Compression.LZ4.Streams.1.1.11\lib\net46\K4os.Compression.LZ4.Streams.dll</HintPath>
+    <Reference Include="K4os.Compression.LZ4.Streams, Version=1.3.5.0, Culture=neutral, PublicKeyToken=2186fa9121ef231d, processorArchitecture=MSIL">
+      <HintPath>..\packages\K4os.Compression.LZ4.Streams.1.3.5\lib\net462\K4os.Compression.LZ4.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="K4os.Hash.xxHash, Version=1.0.6.0, Culture=neutral, PublicKeyToken=32cd54395057cec3, processorArchitecture=MSIL">
-      <HintPath>..\packages\K4os.Hash.xxHash.1.0.6\lib\net46\K4os.Hash.xxHash.dll</HintPath>
+    <Reference Include="K4os.Hash.xxHash, Version=1.0.8.0, Culture=neutral, PublicKeyToken=32cd54395057cec3, processorArchitecture=MSIL">
+      <HintPath>..\packages\K4os.Hash.xxHash.1.0.8\lib\net462\K4os.Hash.xxHash.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualBasic" />
-    <Reference Include="MySql.Data, Version=8.0.25.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
-      <HintPath>..\packages\MySql.Data.8.0.25\lib\net452\MySql.Data.dll</HintPath>
+    <Reference Include="mscorlib" />
+    <Reference Include="MySql.Data, Version=8.2.0.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
+      <HintPath>..\packages\MySql.Data.8.2.0\lib\net462\MySql.Data.dll</HintPath>
     </Reference>
     <Reference Include="NodaTime, Version=1.4.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.4.7\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
-    <Reference Include="Npgsql, Version=4.0.3.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Npgsql.4.0.3\lib\net451\Npgsql.dll</HintPath>
+    <Reference Include="Npgsql, Version=4.0.14.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Npgsql.4.0.14\lib\net451\Npgsql.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
       <HintPath>..\packages\ServiceStack.Client.5.10.4\lib\net45\ServiceStack.Client.dll</HintPath>
@@ -113,13 +114,22 @@
     <Reference Include="System.ComponentModel" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Configuration.ConfigurationManager, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Configuration.ConfigurationManager.4.4.1\lib\net461\System.Configuration.ConfigurationManager.dll</HintPath>
+    </Reference>
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=7.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.7.0.2\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Pipelines, Version=5.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.5.0.2\lib\net461\System.IO.Pipelines.dll</HintPath>
+    </Reference>
     <Reference Include="System.Management" />
-    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
@@ -133,8 +143,8 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.6.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Text.Encodings.Web, Version=4.0.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
@@ -152,11 +162,8 @@
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
-    <Reference Include="Ubiety.Dns.Core, Version=2.2.1.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
-      <HintPath>..\packages\MySql.Data.8.0.25\lib\net452\Ubiety.Dns.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Zstandard.Net, Version=1.1.7.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
-      <HintPath>..\packages\MySql.Data.8.0.25\lib\net452\Zstandard.Net.dll</HintPath>
+    <Reference Include="ZstdSharp, Version=0.7.1.0, Culture=neutral, PublicKeyToken=8d151af33a4ad5cf, processorArchitecture=MSIL">
+      <HintPath>..\packages\ZstdSharp.Port.0.7.1\lib\net461\ZstdSharp.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/packages.config
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/packages.config
@@ -1,36 +1,40 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Aquarius.SDK" version="21.2.3" targetFramework="net472" />
   <package id="Aquarius.SDK.Legacy" version="20.1.2" targetFramework="net472" />
-  <package id="BouncyCastle" version="1.8.9" targetFramework="net472" />
+  <package id="BouncyCastle.Cryptography" version="2.3.1" targetFramework="net472" />
   <package id="Costura.Fody" version="1.6.2" targetFramework="net47" developmentDependency="true" />
   <package id="ExcelDataReader" version="3.6.0" targetFramework="net47" />
   <package id="ExcelDataReader.DataSet" version="3.6.0" targetFramework="net47" />
   <package id="Fastenshtein" version="1.0.0.8" targetFramework="net472" />
   <package id="Fody" version="2.0.0" targetFramework="net47" developmentDependency="true" />
-  <package id="Google.Protobuf" version="3.15.0" targetFramework="net472" />
+  <package id="Google.Protobuf" version="3.21.9" targetFramework="net472" />
   <package id="Humanizer.Core" version="2.8.26" targetFramework="net472" />
-  <package id="K4os.Compression.LZ4" version="1.1.11" targetFramework="net472" />
-  <package id="K4os.Compression.LZ4.Streams" version="1.1.11" targetFramework="net472" />
-  <package id="K4os.Hash.xxHash" version="1.0.6" targetFramework="net472" />
+  <package id="K4os.Compression.LZ4" version="1.3.5" targetFramework="net472" />
+  <package id="K4os.Compression.LZ4.Streams" version="1.3.5" targetFramework="net472" />
+  <package id="K4os.Hash.xxHash" version="1.0.8" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
+  <package id="MySql.Data" version="8.2.0" targetFramework="net472" />
+  <package id="System.Diagnostics.DiagnosticSource" version="7.0.2" targetFramework="net472" />
+  <package id="System.IO.Pipelines" version="5.0.2" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
+  <package id="System.Configuration.ConfigurationManager" version="4.4.1" targetFramework="net472" />
+  <package id="ZstdSharp.Port" version="0.7.1" targetFramework="net472" />
   <package id="log4net" version="2.0.12" targetFramework="net472" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net47" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net47" />
   <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net472" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net47" />
-  <package id="MySql.Data" version="8.0.25" targetFramework="net472" />
   <package id="NodaTime" version="1.4.7" targetFramework="net472" />
-  <package id="Npgsql" version="4.0.3" targetFramework="net472" />
+  <package id="Npgsql" version="4.0.14" targetFramework="net472" />
   <package id="ServiceStack.Client" version="5.10.4" targetFramework="net472" />
   <package id="ServiceStack.HttpClient" version="5.10.4" targetFramework="net472" />
   <package id="ServiceStack.Interfaces" version="5.10.4" targetFramework="net472" />
   <package id="ServiceStack.Logging.Log4Net" version="5.8.0" targetFramework="net472" />
   <package id="ServiceStack.Text" version="5.10.4" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" targetFramework="net472" />
   <package id="System.Text.Encodings.Web" version="4.7.2" targetFramework="net472" />
   <package id="System.Text.Json" version="4.6.0" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />

--- a/TimeSeries/PublicApis/SdkExamples/PointZilla/packages.config
+++ b/TimeSeries/PublicApis/SdkExamples/PointZilla/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.SDK" version="21.2.3" targetFramework="net472" />
+  <package id="Aquarius.SDK" version="24.2.0" targetFramework="net472" />
   <package id="Aquarius.SDK.Legacy" version="20.1.2" targetFramework="net472" />
   <package id="BouncyCastle.Cryptography" version="2.3.1" targetFramework="net472" />
   <package id="Costura.Fody" version="1.6.2" targetFramework="net47" developmentDependency="true" />
@@ -15,6 +15,7 @@
   <package id="K4os.Hash.xxHash" version="1.0.8" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
   <package id="MySql.Data" version="8.2.0" targetFramework="net472" />
+  <package id="ServiceStack.Logging.Log4Net" version="6.0.2" targetFramework="net472" />
   <package id="System.Diagnostics.DiagnosticSource" version="7.0.2" targetFramework="net472" />
   <package id="System.IO.Pipelines" version="5.0.2" targetFramework="net472" />
   <package id="System.Memory" version="4.5.5" targetFramework="net472" />
@@ -24,18 +25,17 @@
   <package id="log4net" version="2.0.12" targetFramework="net472" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net47" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net47" />
-  <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net472" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net47" />
   <package id="NodaTime" version="1.4.7" targetFramework="net472" />
   <package id="Npgsql" version="4.0.14" targetFramework="net472" />
-  <package id="ServiceStack.Client" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.HttpClient" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Interfaces" version="5.10.4" targetFramework="net472" />
-  <package id="ServiceStack.Logging.Log4Net" version="5.8.0" targetFramework="net472" />
-  <package id="ServiceStack.Text" version="5.10.4" targetFramework="net472" />
+  <package id="ServiceStack.Client" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.HttpClient" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Interfaces" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Text" version="6.0.2" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
-  <package id="System.Text.Encodings.Web" version="4.7.2" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="4.6.0" targetFramework="net472" />
   <package id="System.Text.Json" version="4.6.0" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />

--- a/TimeSeries/PublicApis/SdkExamples/SharpShooterReportsRunner/SharpShooterReportsRunner.csproj
+++ b/TimeSeries/PublicApis/SdkExamples/SharpShooterReportsRunner/SharpShooterReportsRunner.csproj
@@ -35,8 +35,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Aquarius.Client, Version=19.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aquarius.SDK.19.4.0\lib\net45\Aquarius.Client.dll</HintPath>
+    <Reference Include="Aquarius.Client, Version=24.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.SDK.24.2.0\lib\net472\Aquarius.Client.dll</HintPath>
     </Reference>
     <Reference Include="DundasWinChart">
       <HintPath>ExternalLibraries\Dundas\DundasWinChart.dll</HintPath>
@@ -44,6 +44,11 @@
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="mscorlib" />
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
@@ -59,25 +64,32 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>ExternalLibraries\Perpetuum\PerpetuumSoft.Reporting.Export.Pdf.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=4.5.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.4.5.12\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.6.0.2\lib\net472\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.HttpClient, Version=4.5.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.HttpClient.4.5.12\lib\net45\ServiceStack.HttpClient.dll</HintPath>
+    <Reference Include="ServiceStack.HttpClient, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.HttpClient.6.0.2\lib\net472\ServiceStack.HttpClient.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.4.5.12\lib\portable-wp80+sl5+net45+win8+wpa81+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.6.0.2\lib\net472\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=4.5.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.4.5.12\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.6.0.2\lib\net472\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
     </Reference>
@@ -85,8 +97,21 @@
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />

--- a/TimeSeries/PublicApis/SdkExamples/SharpShooterReportsRunner/packages.config
+++ b/TimeSeries/PublicApis/SdkExamples/SharpShooterReportsRunner/packages.config
@@ -1,13 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.SDK" version="19.4.0" targetFramework="net472" />
+  <package id="Aquarius.SDK" version="24.2.0" targetFramework="net472" />
+  <package id="ServiceStack.Client" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.HttpClient" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Interfaces" version="6.0.2" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
+  <package id="ServiceStack.Text" version="6.0.2" targetFramework="net472" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
   <package id="log4net" version="2.0.12" targetFramework="net472" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net47" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net47" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net47" />
   <package id="NodaTime" version="1.3.0" targetFramework="net47" />
-  <package id="ServiceStack.Client" version="4.5.12" targetFramework="net47" />
-  <package id="ServiceStack.HttpClient" version="4.5.12" targetFramework="net47" />
-  <package id="ServiceStack.Interfaces" version="4.5.12" targetFramework="net47" />
-  <package id="ServiceStack.Text" version="4.5.12" targetFramework="net47" />
 </packages>

--- a/TimeSeries/PublicApis/SdkExamples/TimeSeriesChangeMonitor/TimeSeriesChangeMonitor.csproj
+++ b/TimeSeries/PublicApis/SdkExamples/TimeSeriesChangeMonitor/TimeSeriesChangeMonitor.csproj
@@ -37,8 +37,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Aquarius.Client, Version=20.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aquarius.SDK.20.1.2\lib\net45\Aquarius.Client.dll</HintPath>
+    <Reference Include="Aquarius.Client, Version=24.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.SDK.24.2.0\lib\net472\Aquarius.Client.dll</HintPath>
     </Reference>
     <Reference Include="Costura, Version=1.6.2.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
       <HintPath>..\packages\Costura.Fody.1.6.2\lib\dotnet\Costura.dll</HintPath>
@@ -50,34 +50,39 @@
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="mscorlib" />
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.5.8.0\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.6.0.2\lib\net472\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.HttpClient, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.HttpClient.5.8.0\lib\net45\ServiceStack.HttpClient.dll</HintPath>
+    <Reference Include="ServiceStack.HttpClient, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.HttpClient.6.0.2\lib\net472\ServiceStack.HttpClient.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.5.8.0\lib\net45\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.6.0.2\lib\net472\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Logging.Log4Net, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Logging.Log4Net.5.8.0\lib\net45\ServiceStack.Logging.Log4Net.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Logging.Log4Net.6.0.2\lib\net472\ServiceStack.Logging.Log4Net.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.5.8.0\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.6.0.2\lib\net472\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.4.5.3\lib\netstandard2.0\System.Memory.dll</HintPath>
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
@@ -86,13 +91,16 @@
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>

--- a/TimeSeries/PublicApis/SdkExamples/TimeSeriesChangeMonitor/packages.config
+++ b/TimeSeries/PublicApis/SdkExamples/TimeSeriesChangeMonitor/packages.config
@@ -1,23 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.SDK" version="20.1.2" targetFramework="net472" />
+  <package id="Aquarius.SDK" version="24.2.0" targetFramework="net472" />
   <package id="Costura.Fody" version="1.6.2" targetFramework="net47" developmentDependency="true" />
   <package id="Fody" version="2.0.0" targetFramework="net47" developmentDependency="true" />
   <package id="Humanizer.Core" version="2.2.0" targetFramework="net47" />
+  <package id="ServiceStack.Client" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.HttpClient" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Interfaces" version="6.0.2" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="log4net" version="2.0.12" targetFramework="net472" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net47" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net47" />
-  <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net472" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net47" />
   <package id="NodaTime" version="1.3.0" targetFramework="net47" />
-  <package id="ServiceStack.Client" version="5.8.0" targetFramework="net472" />
-  <package id="ServiceStack.HttpClient" version="5.8.0" targetFramework="net472" />
-  <package id="ServiceStack.Interfaces" version="5.8.0" targetFramework="net472" />
-  <package id="ServiceStack.Logging.Log4Net" version="5.8.0" targetFramework="net472" />
-  <package id="ServiceStack.Text" version="5.8.0" targetFramework="net472" />
-  <package id="System.Buffers" version="4.4.0" targetFramework="net472" />
-  <package id="System.Memory" version="4.5.3" targetFramework="net472" />
-  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net472" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net472" />
+  <package id="ServiceStack.Logging.Log4Net" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Text" version="6.0.2" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/TimeSeries/PublicApis/SdkExamples/TotalDischargeExternalProcessor/TotalDischargeExternalProcessor.csproj
+++ b/TimeSeries/PublicApis/SdkExamples/TotalDischargeExternalProcessor/TotalDischargeExternalProcessor.csproj
@@ -35,8 +35,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Aquarius.Client, Version=19.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aquarius.SDK.19.4.0\lib\net45\Aquarius.Client.dll</HintPath>
+    <Reference Include="Aquarius.Client, Version=24.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.SDK.24.2.0\lib\net472\Aquarius.Client.dll</HintPath>
     </Reference>
     <Reference Include="Costura, Version=1.6.2.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
       <HintPath>..\packages\Costura.Fody.1.6.2\lib\dotnet\Costura.dll</HintPath>
@@ -48,27 +48,38 @@
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=4.5.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.4.5.12\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.6.0.2\lib\net472\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.HttpClient, Version=4.5.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.HttpClient.4.5.12\lib\net45\ServiceStack.HttpClient.dll</HintPath>
+    <Reference Include="ServiceStack.HttpClient, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.HttpClient.6.0.2\lib\net472\ServiceStack.HttpClient.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.4.5.12\lib\portable-wp80+sl5+net45+win8+wpa81+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.6.0.2\lib\net472\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Logging.Log4Net, Version=4.5.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Logging.Log4Net.4.5.12\lib\net45\ServiceStack.Logging.Log4Net.dll</HintPath>
+    <Reference Include="ServiceStack.Logging.Log4Net, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Logging.Log4Net.6.0.2\lib\net472\ServiceStack.Logging.Log4Net.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=4.5.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.4.5.12\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.6.0.2\lib\net472\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
     </Reference>
@@ -76,6 +87,20 @@
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/TimeSeries/PublicApis/SdkExamples/TotalDischargeExternalProcessor/packages.config
+++ b/TimeSeries/PublicApis/SdkExamples/TotalDischargeExternalProcessor/packages.config
@@ -1,17 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.SDK" version="19.4.0" targetFramework="net472" />
+  <package id="Aquarius.SDK" version="24.2.0" targetFramework="net472" />
   <package id="Costura.Fody" version="1.6.2" targetFramework="net472" developmentDependency="true" />
   <package id="Fody" version="2.0.0" targetFramework="net472" developmentDependency="true" />
   <package id="Humanizer.Core" version="2.7.9" targetFramework="net472" />
+  <package id="ServiceStack.Client" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.HttpClient" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Interfaces" version="6.0.2" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
+  <package id="ServiceStack.Text" version="6.0.2" targetFramework="net472" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
   <package id="log4net" version="2.0.12" targetFramework="net472" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net472" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net472" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net472" />
   <package id="NodaTime" version="1.3.0" targetFramework="net472" />
-  <package id="ServiceStack.Client" version="4.5.12" targetFramework="net472" />
-  <package id="ServiceStack.HttpClient" version="4.5.12" targetFramework="net472" />
-  <package id="ServiceStack.Interfaces" version="4.5.12" targetFramework="net472" />
-  <package id="ServiceStack.Logging.Log4Net" version="4.5.12" targetFramework="net472" />
-  <package id="ServiceStack.Text" version="4.5.12" targetFramework="net472" />
+  <package id="ServiceStack.Logging.Log4Net" version="6.0.2" targetFramework="net472" />
 </packages>

--- a/TimeSeries/PublicApis/SdkExamples/UserImporter/UserImporter.csproj
+++ b/TimeSeries/PublicApis/SdkExamples/UserImporter/UserImporter.csproj
@@ -35,8 +35,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Aquarius.Client, Version=19.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Aquarius.SDK.19.4.0\lib\net45\Aquarius.Client.dll</HintPath>
+    <Reference Include="Aquarius.Client, Version=24.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Aquarius.SDK.24.2.0\lib\net472\Aquarius.Client.dll</HintPath>
     </Reference>
     <Reference Include="Costura, Version=1.6.2.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
       <HintPath>..\packages\Costura.Fody.1.6.2\lib\dotnet\Costura.dll</HintPath>
@@ -49,29 +49,39 @@
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=4.5.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.4.5.12\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.6.0.2\lib\net472\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.HttpClient, Version=4.5.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.HttpClient.4.5.12\lib\net45\ServiceStack.HttpClient.dll</HintPath>
+    <Reference Include="ServiceStack.HttpClient, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.HttpClient.6.0.2\lib\net472\ServiceStack.HttpClient.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.4.5.12\lib\portable-wp80+sl5+net45+win8+wpa81+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.6.0.2\lib\net472\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Logging.Log4Net, Version=1.0.10.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Logging.Log4Net.4.5.6\lib\net45\ServiceStack.Logging.Log4Net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ServiceStack.Logging.Log4Net, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Logging.Log4Net.6.0.2\lib\net472\ServiceStack.Logging.Log4Net.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=4.5.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.4.5.12\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.6.0.2\lib\net472\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
@@ -82,6 +92,20 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/TimeSeries/PublicApis/SdkExamples/UserImporter/packages.config
+++ b/TimeSeries/PublicApis/SdkExamples/UserImporter/packages.config
@@ -1,17 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.SDK" version="19.4.0" targetFramework="net472" />
+  <package id="Aquarius.SDK" version="24.2.0" targetFramework="net472" />
   <package id="Costura.Fody" version="1.6.2" targetFramework="net462" developmentDependency="true" />
   <package id="FileHelpers" version="3.1.5" targetFramework="net462" />
   <package id="Fody" version="2.0.0" targetFramework="net462" developmentDependency="true" />
+  <package id="ServiceStack.Client" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.HttpClient" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Interfaces" version="6.0.2" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net472" />
   <package id="log4net" version="2.0.12" targetFramework="net472" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net462" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net462" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net462" />
   <package id="NodaTime" version="1.3.0" targetFramework="net462" />
-  <package id="ServiceStack.Client" version="4.5.12" targetFramework="net462" />
-  <package id="ServiceStack.HttpClient" version="4.5.12" targetFramework="net462" />
-  <package id="ServiceStack.Interfaces" version="4.5.12" targetFramework="net462" />
-  <package id="ServiceStack.Logging.Log4Net" version="4.5.6" targetFramework="net462" />
-  <package id="ServiceStack.Text" version="4.5.12" targetFramework="net462" />
+  <package id="ServiceStack.Logging.Log4Net" version="6.0.2" targetFramework="net472" />
+  <package id="ServiceStack.Text" version="6.0.2" targetFramework="net472" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Identified vulnerabilities in these NuGet Packages: 

1. `Npgsql`: Upgrade from version 8.0.9 to 8.0.14.
2. `BouncyCastle.Cryptography`: Version 2.3.1. Replaced `BouncyCastle`, which is deprecated and no longer maintainted.
3. `MySql`: Upgrade to version 8.2.0. The previous version (8.0.25) depends on the deprecated `BouncyCastle` package. Therefore, it is necessary to upgrade the `MySql` package to the first version that no longer relies on `BouncyCastle` and instead depends on `BouncyCastle.Cryptography`.
4. `RestSharp`: Upgrade from version 111.4.1 to 112.0.0.